### PR TITLE
fix(backend): change `urlToHandle` function name to `actorToHandle`

### DIFF
--- a/backend/src/activitypub/objects/mention.ts
+++ b/backend/src/activitypub/objects/mention.ts
@@ -1,6 +1,6 @@
 import type { Link } from 'wildebeest/backend/src/activitypub/objects/link'
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
-import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
+import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 
 // https://www.w3.org/TR/activitystreams-vocabulary/#dfn-mention
 export interface Mention extends Link {}
@@ -9,6 +9,6 @@ export function newMention(actor: Actor): Mention {
 	return {
 		type: 'Mention',
 		href: actor.id,
-		name: urlToHandle(actor.id),
+		name: actorToHandle(actor),
 	}
 }

--- a/backend/src/mastodon/follow.ts
+++ b/backend/src/mastodon/follow.ts
@@ -1,6 +1,6 @@
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import * as actors from 'wildebeest/backend/src/activitypub/actors'
-import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
+import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 import { getResultsField } from './utils'
 import { type Database } from 'wildebeest/backend/src/database'
 
@@ -18,7 +18,7 @@ export async function moveFollowers(db: Database, actor: Actor, followers: Array
 	)
 
 	const actorId = actor.id.toString()
-	const actorAcc = urlToHandle(actor.id)
+	const actorAcc = actorToHandle(actor)
 
 	for (let i = 0; i < followers.length; i++) {
 		const follower = new URL(followers[i])
@@ -45,7 +45,7 @@ export async function moveFollowing(db: Database, actor: Actor, followingActors:
 	for (let i = 0; i < followingActors.length; i++) {
 		const following = new URL(followingActors[i])
 		const followingActor = await actors.getAndCache(following, db)
-		const actorAcc = urlToHandle(followingActor.id)
+		const actorAcc = actorToHandle(followingActor)
 
 		const id = crypto.randomUUID()
 		batch.push(stmt.bind(id, actorId, followingActor.id.toString(), actorAcc))

--- a/backend/src/mastodon/microformats.ts
+++ b/backend/src/mastodon/microformats.ts
@@ -1,6 +1,6 @@
 import { parseHandle } from 'wildebeest/backend/src/utils/parse'
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
-import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
+import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 
 function tag(name: string, content: string, attrs: Record<string, string> = {}): string {
 	let htmlAttrs = ''
@@ -35,7 +35,7 @@ export function enrichStatus(status: string, mentions: Array<Actor>): string {
 		.replace(mentionedEmailRegex, (_, matchPrefix: string, email: string, matchSuffix: string) => {
 			// ensure that the match is part of the mentions array
 			for (let i = 0, len = mentions.length; i < len; i++) {
-				if (email === urlToHandle(mentions[i].id)) {
+				if (email === actorToHandle(mentions[i])) {
 					return `${matchPrefix}${getMentionSpan(email)}${matchSuffix}`
 				}
 			}

--- a/backend/src/mastodon/notification.ts
+++ b/backend/src/mastodon/notification.ts
@@ -3,7 +3,7 @@ import { type Database } from 'wildebeest/backend/src/database'
 import { defaultImages } from 'wildebeest/config/accounts'
 import type { JWK } from 'wildebeest/backend/src/webpush/jwk'
 import * as actors from 'wildebeest/backend/src/activitypub/actors'
-import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
+import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 import { loadExternalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
 import { generateWebPushMessage } from 'wildebeest/backend/src/webpush'
 import { getActorById } from 'wildebeest/backend/src/activitypub/actors'
@@ -242,7 +242,7 @@ export async function getNotifications(db: Database, actor: Actor, domain: strin
 			continue
 		}
 
-		const acct = urlToHandle(notifFromActorId)
+		const acct = actorToHandle(notifFromActor)
 		const notifFromAccount = await loadExternalMastodonAccount(acct, notifFromActor)
 
 		const notif: Notification = {
@@ -256,7 +256,7 @@ export async function getNotifications(db: Database, actor: Actor, domain: strin
 			const actorId = new URL(result.original_actor_id)
 			const actor = await actors.getAndCache(actorId, db)
 
-			const acct = urlToHandle(actorId)
+			const acct = actorToHandle(actor)
 			const account = await loadExternalMastodonAccount(acct, actor)
 
 			notif.status = {

--- a/backend/src/utils/handle.ts
+++ b/backend/src/utils/handle.ts
@@ -1,3 +1,5 @@
+import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
+
 // Naive way of transforming an Actor ObjectID into a handle like WebFinger uses
 export function urlToHandle(input: URL): string {
 	const { pathname, host } = input
@@ -7,4 +9,11 @@ export function urlToHandle(input: URL): string {
 	}
 	const localPart = parts[parts.length - 1]
 	return `${localPart}@${host}`
+}
+
+export function actorToHandle(actor: Actor): string {
+	if (actor.preferredUsername !== undefined) {
+		return `${actor.preferredUsername}@${actor.id.host}`
+	}
+	return urlToHandle(actor.id)
 }

--- a/functions/api/v1/accounts/[id]/followers.ts
+++ b/functions/api/v1/accounts/[id]/followers.ts
@@ -6,7 +6,7 @@ import { actorURL } from 'wildebeest/backend/src/activitypub/actors'
 import { cors } from 'wildebeest/backend/src/utils/cors'
 import { loadExternalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
 import { parseHandle } from 'wildebeest/backend/src/utils/parse'
-import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
+import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 import { MastodonAccount } from 'wildebeest/backend/src/types/account'
 import type { ContextData } from 'wildebeest/backend/src/types/context'
 import type { Env } from 'wildebeest/backend/src/types/env'
@@ -46,7 +46,7 @@ async function getRemoteFollowers(request: Request, handle: Handle, db: Database
 	const followers = await loadActors(db, followersIds)
 
 	const promises = followers.map((actor) => {
-		const acct = urlToHandle(actor.id)
+		const acct = actorToHandle(actor)
 		return loadExternalMastodonAccount(acct, actor, false)
 	})
 
@@ -68,10 +68,10 @@ async function getLocalFollowers(request: Request, handle: Handle, db: Database)
 
 	for (let i = 0, len = followers.length; i < len; i++) {
 		const id = new URL(followers[i])
-		const acct = urlToHandle(id)
 
 		try {
 			const actor = await actors.getAndCache(id, db)
+			const acct = actorToHandle(actor)
 			out.push(await loadExternalMastodonAccount(acct, actor))
 		} catch (err: any) {
 			console.warn(`failed to retrieve follower (${id}): ${err.message}`)

--- a/functions/api/v1/accounts/[id]/following.ts
+++ b/functions/api/v1/accounts/[id]/following.ts
@@ -6,7 +6,7 @@ import { actorURL } from 'wildebeest/backend/src/activitypub/actors'
 import { cors } from 'wildebeest/backend/src/utils/cors'
 import { loadExternalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
 import { parseHandle } from 'wildebeest/backend/src/utils/parse'
-import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
+import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 import { MastodonAccount } from 'wildebeest/backend/src/types/account'
 import type { ContextData } from 'wildebeest/backend/src/types/context'
 import * as localFollow from 'wildebeest/backend/src/mastodon/follow'
@@ -46,7 +46,7 @@ async function getRemoteFollowing(request: Request, handle: Handle, db: Database
 	const following = await loadActors(db, followingIds)
 
 	const promises = following.map((actor) => {
-		const acct = urlToHandle(actor.id)
+		const acct = actorToHandle(actor)
 		return loadExternalMastodonAccount(acct, actor, false)
 	})
 
@@ -68,10 +68,10 @@ async function getLocalFollowing(request: Request, handle: Handle, db: Database)
 
 	for (let i = 0, len = following.length; i < len; i++) {
 		const id = new URL(following[i])
-		const acct = urlToHandle(id)
 
 		try {
 			const actor = await actors.getAndCache(id, db)
+			const acct = actorToHandle(actor)
 			out.push(await loadExternalMastodonAccount(acct, actor))
 		} catch (err: any) {
 			console.warn(`failed to retrieve following (${id}): ${err.message}`)

--- a/functions/api/v1/notifications/[id].ts
+++ b/functions/api/v1/notifications/[id].ts
@@ -2,7 +2,7 @@
 
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
 import type { Notification, NotificationsQueryResult } from 'wildebeest/backend/src/types/notification'
-import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
+import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 import { getActorById } from 'wildebeest/backend/src/activitypub/actors'
 import { loadExternalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
 import type { Person } from 'wildebeest/backend/src/activitypub/actors'
@@ -45,7 +45,7 @@ export async function handleRequest(
 		throw new Error('unknown from actor')
 	}
 
-	const acct = urlToHandle(from_actor_id)
+	const acct = actorToHandle(fromActor)
 	const fromAccount = await loadExternalMastodonAccount(acct, fromActor)
 
 	const out: Notification = {

--- a/functions/api/v1/statuses/[id].ts
+++ b/functions/api/v1/statuses/[id].ts
@@ -11,7 +11,7 @@ import { getMastodonStatusById, toMastodonStatusFromObject } from 'wildebeest/ba
 import type { Env } from 'wildebeest/backend/src/types/env'
 import * as errors from 'wildebeest/backend/src/errors'
 import { getObjectByMastodonId, deleteObject } from 'wildebeest/backend/src/activitypub/objects'
-import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
+import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 import { deliverFollowers } from 'wildebeest/backend/src/activitypub/deliver'
 import type { Queue, DeliverMessageBody } from 'wildebeest/backend/src/types/queue'
 import * as timeline from 'wildebeest/backend/src/mastodon/timeline'
@@ -50,8 +50,8 @@ export async function handleRequestGet(
 
 	// future validation for private statuses
 	/*
-	if (status.private && status.account.id !== urlToHandle(connectedActor.id)) {
-		return errors.notAuthorized("status is private");
+	if (status.private && status.account.id !== actorToHandle(connectedActor)) {
+		return errors.notAuthorized('status is private')
 	}
 	*/
 
@@ -80,7 +80,7 @@ export async function handleRequestDelete(
 	if (status === null) {
 		return errors.statusNotFound(id)
 	}
-	if (status.account.id !== urlToHandle(connectedActor.id)) {
+	if (status.account.id !== actorToHandle(connectedActor)) {
 		return errors.statusNotFound(id)
 	}
 

--- a/functions/api/v2/search.ts
+++ b/functions/api/v2/search.ts
@@ -2,7 +2,7 @@
 import type { Env } from 'wildebeest/backend/src/types/env'
 import { cors } from 'wildebeest/backend/src/utils/cors'
 import { queryAcct } from 'wildebeest/backend/src/webfinger'
-import { urlToHandle } from 'wildebeest/backend/src/utils/handle'
+import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 import { MastodonAccount } from 'wildebeest/backend/src/types/account'
 import { parseHandle } from 'wildebeest/backend/src/utils/parse'
 import { loadExternalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
@@ -75,7 +75,7 @@ export async function handleRequest(db: Database, request: Request): Promise<Res
 				for (let i = 0, len = results.length; i < len; i++) {
 					const row: any = results[i]
 					const actor = personFromRow(row)
-					const acct = urlToHandle(new URL(row.id))
+					const acct = actorToHandle(actor)
 					out.accounts.push(await loadExternalMastodonAccount(acct, actor))
 				}
 			}


### PR DESCRIPTION
Refactor the code to use the new `actorToHandle` function instead of the deprecated `urlToHandle` function.
The `actorToHandle` function is used to transform an Actor object into a handle.