### PR TITLE
Fix duplicated execution of CI on Pull Request

### DIFF
--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -1,6 +1,8 @@
 name: Pull request checks
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 # This allows a subsequently queued workflow run to interrupt previous runs


### PR DESCRIPTION
Previously, the CI workflow was executed multiple times on Pull Requests.
This PR fixes the issue by adding a branch restriction to ensure the push-workflow runs only on the main branch.