### PR TITLE
Make `signRequest` prioritize `publicKey.id`

### DIFF
--- a/backend/src/activitypub/deliver.ts
+++ b/backend/src/activitypub/deliver.ts
@@ -21,6 +21,7 @@ export async function deliverToActor(
 ) {
 	const headers = {
 		Accept: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+		'Content-Type': 'application/activity+json',
 		'User-Agent': getFederationUA(domain),
 	}
 
@@ -33,7 +34,7 @@ export async function deliverToActor(
 	})
 	const digest = await generateDigestHeader(body)
 	req.headers.set('Digest', digest)
-	await signRequest(req, signingKey, new URL(from.id))
+	await signRequest(req, signingKey, new URL(from.publicKey?.id ?? from.id))
 
 	const res = await fetch(req)
 	if (!res.ok) {

--- a/backend/src/mastodon/status.ts
+++ b/backend/src/mastodon/status.ts
@@ -114,7 +114,7 @@ export async function toMastodonStatusFromRow(domain: string, db: Database, row:
 		// D1 uses a string for JSON properties
 		properties = JSON.parse(row.properties)
 	}
-	const author = actors.personFromRow({
+	const author = actors.actorFromRow({
 		id: row.actor_id,
 		cdate: row.actor_cdate,
 		properties: row.actor_properties,

--- a/backend/src/middleware/main.ts
+++ b/backend/src/middleware/main.ts
@@ -28,9 +28,9 @@ async function loadContextData(db: Database, clientId: string, email: string, ct
 		return false
 	}
 
-	const person = actors.personFromRow(row)
+	const actor = actors.actorFromRow(row)
 
-	ctx.data.connectedActor = person
+	ctx.data.connectedActor = actor
 	ctx.data.identity = { email }
 	ctx.data.clientId = clientId
 

--- a/backend/src/utils/auth/getAdmins.ts
+++ b/backend/src/utils/auth/getAdmins.ts
@@ -1,5 +1,5 @@
 import { type Database } from 'wildebeest/backend/src/database'
-import { Person, personFromRow } from 'wildebeest/backend/src/activitypub/actors'
+import { Person, actorFromRow } from 'wildebeest/backend/src/activitypub/actors'
 
 export async function getAdmins(db: Database): Promise<Person[]> {
 	let rows: unknown[] = []
@@ -11,5 +11,5 @@ export async function getAdmins(db: Database): Promise<Person[]> {
 		/* empty */
 	}
 
-	return rows.map(personFromRow)
+	return rows.map(actorFromRow) as Person[]
 }

--- a/functions/api/v2/search.ts
+++ b/functions/api/v2/search.ts
@@ -6,7 +6,7 @@ import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 import { MastodonAccount } from 'wildebeest/backend/src/types/account'
 import { parseHandle } from 'wildebeest/backend/src/utils/parse'
 import { loadExternalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
-import { personFromRow } from 'wildebeest/backend/src/activitypub/actors'
+import { actorFromRow } from 'wildebeest/backend/src/activitypub/actors'
 import type { Handle } from 'wildebeest/backend/src/utils/parse'
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
 
@@ -74,7 +74,7 @@ export async function handleRequest(db: Database, request: Request): Promise<Res
 			if (results !== undefined) {
 				for (let i = 0, len = results.length; i < len; i++) {
 					const row: any = results[i]
-					const actor = personFromRow(row)
+					const actor = actorFromRow(row)
 					const acct = actorToHandle(actor)
 					out.accounts.push(await loadExternalMastodonAccount(acct, actor))
 				}


### PR DESCRIPTION
This change ensures that the `signRequest` function uses the `publicKey.id` field instead of the actor's `id` field when signing requests.