### PR TITLE
Implement `api/v1/preferences`

### DIFF
--- a/backend/src/activitypub/actors/index.ts
+++ b/backend/src/activitypub/actors/index.ts
@@ -209,6 +209,7 @@ export async function createPerson(
 		)
 		.bind(id, PERSON, email, userKeyPair.pubKey, privkey, salt, JSON.stringify(properties), admin ? 1 : null)
 		.first()
+	await db.prepare('INSERT INTO actor_preferences(id) VALUES(?)').bind(id).run()
 
 	return actorFromRow(row) as Person
 }

--- a/backend/src/mastodon/account.ts
+++ b/backend/src/mastodon/account.ts
@@ -1,4 +1,4 @@
-import { MastodonAccount } from 'wildebeest/backend/src/types/account'
+import type { MastodonAccount, Preference } from 'wildebeest/backend/src/types/account'
 import { unwrapPrivateKey } from 'wildebeest/backend/src/utils/key-ops'
 import { Actor } from '../activitypub/actors'
 import { defaultImages } from 'wildebeest/config/accounts'
@@ -96,5 +96,24 @@ export async function getSigningKey(instanceKey: string, db: Database, actor: Ac
 	} else {
 		// D1
 		return unwrapPrivateKey(instanceKey, new Uint8Array(privkey), new Uint8Array(privkey_salt))
+	}
+}
+
+export async function getPreference(db: Database, actor: Actor): Promise<Preference> {
+	const query = `
+SELECT
+	posting_default_visibility,
+	posting_default_sensitive,
+	posting_default_language,
+	reading_expand_spoilers
+FROM actor_preferences WHERE id=?
+`
+	const row: any = await db.prepare(query).bind(actor.id.toString()).first()
+	return {
+		posting_default_visibility: row.posting_default_visibility,
+		posting_default_sensitive: row.posting_default_sensitive === 1,
+		posting_default_language: row.posting_default_language,
+		reading_expand_media: 'default',
+		reading_expand_spoilers: row.reading_expand_spoilers === 1,
 	}
 }

--- a/backend/src/types/account.ts
+++ b/backend/src/types/account.ts
@@ -68,3 +68,13 @@ export type Field = {
 	value: string
 	verified_at?: string
 }
+
+export type ReadingExpandMedia = 'default' | 'show_all' | 'hide_all'
+
+export type Preference = {
+	posting_default_visibility: Privacy
+	posting_default_sensitive: boolean
+	posting_default_language: string | null
+	reading_expand_media: ReadingExpandMedia
+	reading_expand_spoilers: boolean
+}

--- a/backend/test/mastodon/accounts.spec.ts
+++ b/backend/test/mastodon/accounts.spec.ts
@@ -21,6 +21,7 @@ import { insertLike } from 'wildebeest/backend/src/mastodon/like'
 import { insertReblog } from 'wildebeest/backend/src/mastodon/reblog'
 import * as filters from 'wildebeest/functions/api/v1/filters'
 import { createStatus } from 'wildebeest/backend/src/mastodon/status'
+import * as preferences from 'wildebeest/functions/api/v1/preferences'
 
 const userKEK = 'test_kek2'
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
@@ -1066,6 +1067,25 @@ describe('Mastodon APIs', () => {
 
 			const data = await res.json<any>()
 			assert.equal(data.length, 0)
+		})
+
+		test('preferences', async () => {
+			const db = await makeDB()
+			const actor = await createPerson(domain, db, userKEK, 'alice@example.com')
+			const connectedActor = actor
+
+			const context: any = { data: { connectedActor }, env: { DATABASE: db } }
+			const res = await preferences.onRequest(context)
+			assert.equal(res.status, 200)
+			assertCORS(res)
+			assertJSON(res)
+
+			const data = await res.json<any>()
+			assert.equal(data['posting:default:language'], null)
+			assert.equal(data['posting:default:sensitive'], false)
+			assert.equal(data['posting:default:visibility'], 'public')
+			assert.equal(data['reading:expand:media'], 'default')
+			assert.equal(data['reading:expand:spoilers'], false)
 		})
 	})
 })

--- a/functions/api/v1/preferences.ts
+++ b/functions/api/v1/preferences.ts
@@ -1,0 +1,39 @@
+// https://docs.joinmastodon.org/methods/preferences/#get
+
+import { ContextData } from 'wildebeest/backend/src/types/context'
+import type { Env } from 'wildebeest/backend/src/types/env'
+import { cors } from 'wildebeest/backend/src/utils/cors'
+import * as errors from 'wildebeest/backend/src/errors'
+import { getPreference } from 'wildebeest/backend/src/mastodon/account'
+import { getDatabase } from 'wildebeest/backend/src/database'
+import { Privacy, ReadingExpandMedia } from 'wildebeest/backend/src/types'
+
+type PreferenceResponse = {
+	'posting:default:visibility': Privacy
+	'posting:default:sensitive': boolean
+	'posting:default:language': string | null
+	'reading:expand:media': ReadingExpandMedia
+	'reading:expand:spoilers': boolean
+}
+
+export const onRequest: PagesFunction<Env, any, ContextData> = async ({ data, env }) => {
+	if (!data.connectedActor) {
+		return errors.notAuthorized('no connected user')
+	}
+
+	const preference = await getPreference(await getDatabase(env), data.connectedActor)
+	const res: PreferenceResponse = {
+		'posting:default:visibility': preference.posting_default_visibility,
+		'posting:default:sensitive': preference.posting_default_sensitive,
+		'posting:default:language': preference.posting_default_language,
+		'reading:expand:media': preference.reading_expand_media,
+		'reading:expand:spoilers': preference.reading_expand_spoilers,
+	}
+
+	const headers = {
+		...cors(),
+		'content-type': 'application/json; charset=utf-8',
+	}
+
+	return new Response(JSON.stringify(res), { headers })
+}

--- a/migrations/0011_add_actor_preference.sql
+++ b/migrations/0011_add_actor_preference.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS actor_preferences (
+    id TEXT PRIMARY KEY,
+    posting_default_visibility TEXT NOT NULL DEFAULT 'public',
+    posting_default_sensitive INTEGER NOT NULL DEFAULT 0,
+    posting_default_language TEXT,
+    reading_expand_media TEXT NOT NULL DEFAULT 'default',
+    reading_expand_spoilers INTEGER NOT NULL DEFAULT 0,
+
+    FOREIGN KEY(id) REFERENCES actors(id) ON DELETE CASCADE
+);
+
+INSERT INTO actor_preferences SELECT id, 'public', 0, null, 'default', 0 FROM actors;


### PR DESCRIPTION
Closes #13

Although adding a new column to the actors table is an option, I decided to do this because it is easier to discard the separate table in case there is a version upgrade of cloudflare/wildebeest.