### PR TITLE
Fix timeline sorting logic

### DIFF
--- a/backend/src/mastodon/timeline.ts
+++ b/backend/src/mastodon/timeline.ts
@@ -64,7 +64,7 @@ WHERE
      AND ${db.qb.jsonExtractIsNull('objects.properties', 'inReplyTo')}
      AND (outbox_objects.target = '${PUBLIC_GROUP}' OR outbox_objects.target IN ${db.qb.set('?3')})
 GROUP BY objects.id ${db.qb.psqlOnly(', actors.id, outbox_objects.actor_id, outbox_objects.published_date')}
-ORDER by outbox_objects.published_date DESC
+ORDER by strftime('%Y-%m-%d %H:%M:%f', outbox_objects.published_date) DESC
 LIMIT ?4
 `
 	const DEFAULT_LIMIT = 20
@@ -142,7 +142,7 @@ WHERE objects.type='Note'
 GROUP BY objects.id ${db.qb.psqlOnly(
 		', actors.id, actors.cdate, actors.properties, outbox_objects.actor_id, outbox_objects.published_date'
 	)}
-ORDER by outbox_objects.published_date DESC
+ORDER by strftime('%Y-%m-%d %H:%M:%f', outbox_objects.published_date) DESC
 LIMIT ?1 OFFSET ?2
 `
 	const DEFAULT_LIMIT = 20

--- a/functions/api/v1/accounts/[id]/statuses.ts
+++ b/functions/api/v1/accounts/[id]/statuses.ts
@@ -162,7 +162,7 @@ WHERE objects.type='Note'
       AND outbox_objects.target = '${PUBLIC_GROUP}'
       AND outbox_objects.actor_id = ?1
       AND outbox_objects.cdate > ?2${db.qb.psqlOnly('::timestamp')}
-ORDER by outbox_objects.published_date DESC
+ORDER by strftime('%Y-%m-%d %H:%M:%f', outbox_objects.published_date) DESC
 LIMIT ?3 OFFSET ?4
 `
 


### PR DESCRIPTION
Close #14

Since published_date has several formats, it is necessary to absorb the differences.

examples

- `2023-07-04 09:18:08.123`
- `2023-07-04T08:27:15Z`
- `2023-07-08T00:17:59.325Z`