### PR TITLE
Revert Terraform cloudflare to v3.31.0

### DIFF
--- a/tf/main.tf
+++ b/tf/main.tf
@@ -67,7 +67,7 @@ terraform {
   required_providers {
     cloudflare = {
       source = "cloudflare/cloudflare"
-      version = "3.35.0"
+      version = "3.31.0"
     }
 
     random = {


### PR DESCRIPTION
Starting with v3.32.0, we need to create a Cloudflare Pages preview environment, and I cannot accept this at this time, so we are reverting.