### PR TITLE
Change Actor to have correct Mastodon ID

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,7 @@
+INSTANCE_TITLE=Test Wildebeest
+INSTANCE_DESCR=My Wildebeest Instance
+ACCESS_AUTH_DOMAIN=0.0.0.0.cloudflareaccess.com
+ACCESS_AUD=DEV_AUD
+ADMIN_EMAIL=george@test.email
+DOMAIN=0.0.0.0
+userKEK=dev_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .wrangler/state/d1/*.sqlite3
 .DS_Store
+.dev.vars
 /test-results/
 /playwright-report/
 /playwright/.cache/

--- a/backend/src/accounts/getAccount.ts
+++ b/backend/src/accounts/getAccount.ts
@@ -43,5 +43,5 @@ async function getLocalAccount(domain: string, db: Database, handle: LocalHandle
 		return null
 	}
 
-	return await loadLocalMastodonAccount(db, actor)
+	return await loadLocalMastodonAccount(db, actor, handle)
 }

--- a/backend/src/accounts/getAccount.ts
+++ b/backend/src/accounts/getAccount.ts
@@ -1,47 +1,51 @@
 // https://docs.joinmastodon.org/methods/accounts/#get
 
-import { actorURL, getActorById } from 'wildebeest/backend/src/activitypub/actors'
+import {
+	actorURL,
+	getActorById,
+	getActorByMastodonId,
+	getActorByRemoteHandle,
+} from 'wildebeest/backend/src/activitypub/actors'
 import { type Database } from 'wildebeest/backend/src/database'
 import { loadExternalMastodonAccount, loadLocalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
-import { MastodonAccount } from 'wildebeest/backend/src/types'
+import { MastodonAccount, MastodonId } from 'wildebeest/backend/src/types'
 import { adjustLocalHostDomain } from 'wildebeest/backend/src/utils/adjustLocalHostDomain'
-import { Handle, isLocalHandle, LocalHandle, parseHandle, RemoteHandle } from 'wildebeest/backend/src/utils/handle'
-import { queryAcct } from 'wildebeest/backend/src/webfinger/index'
+import { actorToHandle, Handle, isLocalHandle, LocalHandle, parseHandle } from 'wildebeest/backend/src/utils/handle'
 
 export function isLocalAccount(domain: string, handle: Handle): handle is LocalHandle {
 	return isLocalHandle(handle) || handle.domain === domain
 }
 
-export async function getAccount(domain: string, accountId: string, db: Database): Promise<MastodonAccount | null> {
-	const handle = parseHandle(accountId)
+export async function getAccount(domain: string, db: Database, acct: string): Promise<MastodonAccount | null> {
+	const handle = parseHandle(acct)
 
 	if (isLocalAccount(domain, handle)) {
-		// Retrieve the statuses from a local user
-		return getLocalAccount(domain, db, handle)
+		const actorId = actorURL(adjustLocalHostDomain(domain), handle)
+		const actor = await getActorById(db, actorId)
+		if (actor === null) {
+			return null
+		}
+		return await loadLocalMastodonAccount(db, actor, handle)
 	}
-	// Retrieve the statuses of a remote actor
-	return getRemoteAccount(handle, db)
-}
-
-async function getRemoteAccount(handle: RemoteHandle, db: Database): Promise<MastodonAccount | null> {
-	// TODO: using webfinger isn't the optimal implementation. We could cache
-	// the object in D1 and directly query the remote API, indicated by the actor's
-	// url field. For now, let's keep it simple.
-	const actor = await queryAcct(handle, db)
+	const actor = await getActorByRemoteHandle(db, handle)
 	if (actor === null) {
 		return null
 	}
-
-	return await loadExternalMastodonAccount(actor, true, handle)
+	return await loadExternalMastodonAccount(db, actor, handle, true)
 }
 
-async function getLocalAccount(domain: string, db: Database, handle: LocalHandle): Promise<MastodonAccount | null> {
-	const actorId = actorURL(adjustLocalHostDomain(domain), handle)
-
-	const actor = await getActorById(db, actorId)
+export async function getAccountByMastodonId(
+	domain: string,
+	db: Database,
+	id: MastodonId
+): Promise<MastodonAccount | null> {
+	const actor = await getActorByMastodonId(db, id)
 	if (actor === null) {
 		return null
 	}
-
-	return await loadLocalMastodonAccount(db, actor, handle)
+	const handle = actorToHandle(actor)
+	if (isLocalAccount(domain, handle)) {
+		return await loadLocalMastodonAccount(db, actor)
+	}
+	return await loadExternalMastodonAccount(db, actor, handle, true)
 }

--- a/backend/src/activitypub/activities/move.ts
+++ b/backend/src/activitypub/activities/move.ts
@@ -1,7 +1,7 @@
 import { MoveActivity } from 'wildebeest/backend/src/activitypub/activities'
 import { getActorById, getAndCache } from 'wildebeest/backend/src/activitypub/actors'
 import { getApId } from 'wildebeest/backend/src/activitypub/objects'
-import { getMetadata, loadItems } from 'wildebeest/backend/src/activitypub/objects/collection'
+import { getMetadata, loadItems, OrderedCollection } from 'wildebeest/backend/src/activitypub/objects/collection'
 import { Database } from 'wildebeest/backend/src/database'
 import { moveFollowers, moveFollowing } from 'wildebeest/backend/src/mastodon/follow'
 
@@ -27,8 +27,8 @@ export async function handleMoveActivity(domain: string, activity: MoveActivity,
 
 	// move followers
 	{
-		const collection = await getMetadata(fromActor.followers)
-		collection.items = await loadItems<string>(collection)
+		const collection: OrderedCollection<string> = await getMetadata(fromActor.followers)
+		collection.items = await loadItems(collection)
 
 		// TODO: eventually move to queue and move workers
 		while (collection.items.length > 0) {
@@ -40,8 +40,8 @@ export async function handleMoveActivity(domain: string, activity: MoveActivity,
 
 	// move following
 	{
-		const collection = await getMetadata(fromActor.following)
-		collection.items = await loadItems<string>(collection)
+		const collection: OrderedCollection<string> = await getMetadata(fromActor.following)
+		collection.items = await loadItems(collection)
 
 		// TODO: eventually move to queue and move workers
 		while (collection.items.length > 0) {

--- a/backend/src/activitypub/actors/follow.ts
+++ b/backend/src/activitypub/actors/follow.ts
@@ -15,14 +15,14 @@ export async function countFollowers(actor: Actor): Promise<number> {
 }
 
 export async function getFollowers(actor: Actor): Promise<OrderedCollection<string>> {
-	const collection = await getMetadata(actor.followers)
-	collection.items = await loadItems<string>(collection)
+	const collection: OrderedCollection<string> = await getMetadata(actor.followers)
+	collection.items = await loadItems(collection)
 	return collection
 }
 
 export async function getFollowing(actor: Actor): Promise<OrderedCollection<string>> {
-	const collection = await getMetadata(actor.following)
-	collection.items = await loadItems<string>(collection)
+	const collection: OrderedCollection<string> = await getMetadata(actor.following)
+	collection.items = await loadItems(collection)
 	return collection
 }
 

--- a/backend/src/activitypub/actors/index.ts
+++ b/backend/src/activitypub/actors/index.ts
@@ -431,7 +431,7 @@ export function actorFromRow<T extends Actor>(row: ActorRow<T>) {
 	return {
 		type: row.type,
 		id,
-		url: new URL('@' + preferredUsername, 'https://' + domain),
+		url: handleToUrl({ localPart: preferredUsername ?? name ?? 'unnamed', domain }),
 		published: new Date(row.cdate).toISOString(),
 		icon,
 		image,

--- a/backend/src/activitypub/actors/index.ts
+++ b/backend/src/activitypub/actors/index.ts
@@ -40,13 +40,13 @@ export interface Person extends Actor {
 	type: typeof PERSON
 }
 
-export async function get(url: string | URL): Promise<Actor> {
+export async function fetchActor(url: string | URL): Promise<Actor> {
 	const headers = {
 		accept: 'application/activity+json',
 	}
-	const res = await fetch(url.toString(), { headers })
+	const res = await fetch(url, { headers })
 	if (!res.ok) {
-		throw new Error(`${url} returned: ${res.status}`)
+		throw new Error(`${url.toString()} returned: ${res.status}`)
 	}
 
 	const data = await res.json<any>()
@@ -100,7 +100,7 @@ export async function getAndCache(url: URL, db: Database): Promise<Actor> {
 		}
 	}
 
-	const actor = await get(url)
+	const actor = await fetchActor(url)
 	if (!actor.type || !actor.id) {
 		throw new Error('missing fields on Actor')
 	}

--- a/backend/src/activitypub/actors/index.ts
+++ b/backend/src/activitypub/actors/index.ts
@@ -389,7 +389,8 @@ export function actorFromRow(row: any): Actor {
 		outbox: properties.outbox,
 		following: properties.following,
 		followers: properties.followers,
-		discoverable: true,
+		discoverable: properties.discoverable ?? false,
+		manuallyApprovesFollowers: properties.manuallyApprovesFollowers ?? false,
 		publicKey: publicKey ?? undefined,
 		alsoKnownAs: properties.alsoKnownAs ?? undefined,
 

--- a/backend/src/activitypub/actors/index.ts
+++ b/backend/src/activitypub/actors/index.ts
@@ -6,8 +6,8 @@ import { Handle } from 'wildebeest/backend/src/utils/handle'
 import { generateUserKey } from 'wildebeest/backend/src/utils/key-ops'
 import { defaultImages } from 'wildebeest/config/accounts'
 
-const PERSON = 'Person'
 const isTesting = typeof jest !== 'undefined'
+
 export const emailSymbol = Symbol()
 export const isAdminSymbol = Symbol()
 
@@ -20,6 +20,7 @@ export function actorURL(domain: string, obj: { perferredUsername: string } | Pi
 
 // https://www.w3.org/TR/activitystreams-vocabulary/#actor-types
 export interface Actor extends ApObject {
+	type: 'Person' | 'Service' | 'Organization' | 'Group' | 'Application'
 	inbox: URL
 	outbox: URL
 	following: URL
@@ -34,6 +35,8 @@ export interface Actor extends ApObject {
 	[emailSymbol]: string
 	[isAdminSymbol]: boolean
 }
+
+const PERSON = 'Person'
 
 // https://www.w3.org/TR/activitystreams-vocabulary/#dfn-person
 export interface Person extends Actor {

--- a/backend/src/activitypub/actors/index.ts
+++ b/backend/src/activitypub/actors/index.ts
@@ -34,6 +34,7 @@ export interface Actor extends ApObject {
 	following: URL
 	followers: URL
 	discoverable: boolean
+	manuallyApprovesFollowers?: boolean
 	alsoKnownAs?: string[]
 	publicKey?: {
 		id: string

--- a/backend/src/activitypub/actors/outbox.ts
+++ b/backend/src/activitypub/actors/outbox.ts
@@ -33,7 +33,7 @@ export async function addObjectInOutbox(
 }
 
 export async function get(actor: Actor, limit?: number): Promise<OrderedCollection<Activity>> {
-	const collection = await getMetadata(actor.outbox)
+	const collection = await getMetadata<any>(actor.outbox)
 	collection.items = await loadItems(collection, limit ?? 20)
 
 	return collection

--- a/backend/src/activitypub/objects/collection.ts
+++ b/backend/src/activitypub/objects/collection.ts
@@ -1,6 +1,6 @@
 import type { ApObject } from 'wildebeest/backend/src/activitypub/objects'
 
-export interface Collection<T> extends ApObject {
+export interface Collection<T extends ApObject> extends ApObject {
 	totalItems: number
 	current?: string
 	first: URL
@@ -8,7 +8,7 @@ export interface Collection<T> extends ApObject {
 	items: Array<T>
 }
 
-export type OrderedCollection<T> = Collection<T>
+export type OrderedCollection<T extends ApObject> = Collection<T>
 
 export interface OrderedCollectionPage<T> extends ApObject {
 	next?: string
@@ -19,16 +19,16 @@ const headers = {
 	accept: 'application/activity+json',
 }
 
-export async function getMetadata(url: URL): Promise<OrderedCollection<any>> {
+export async function getMetadata<T extends ApObject>(url: URL): Promise<OrderedCollection<T>> {
 	const res = await fetch(url, { headers })
 	if (!res.ok) {
 		throw new Error(`${url} returned ${res.status}`)
 	}
 
-	return res.json<OrderedCollection<any>>()
+	return res.json<OrderedCollection<T>>()
 }
 
-export async function loadItems<T>(collection: OrderedCollection<T>, max?: number): Promise<Array<T>> {
+export async function loadItems<T extends ApObject>(collection: OrderedCollection<T>, max?: number): Promise<Array<T>> {
 	const items = []
 	let pageUrl = collection.first
 

--- a/backend/src/activitypub/objects/collection.ts
+++ b/backend/src/activitypub/objects/collection.ts
@@ -1,6 +1,6 @@
 import type { ApObject } from 'wildebeest/backend/src/activitypub/objects'
 
-export interface Collection<T extends ApObject> extends ApObject {
+export interface Collection<T> extends ApObject {
 	totalItems: number
 	current?: string
 	first: URL
@@ -8,7 +8,7 @@ export interface Collection<T extends ApObject> extends ApObject {
 	items: Array<T>
 }
 
-export type OrderedCollection<T extends ApObject> = Collection<T>
+export type OrderedCollection<T> = Collection<T>
 
 export interface OrderedCollectionPage<T> extends ApObject {
 	next?: string
@@ -19,7 +19,7 @@ const headers = {
 	accept: 'application/activity+json',
 }
 
-export async function getMetadata<T extends ApObject>(url: URL): Promise<OrderedCollection<T>> {
+export async function getMetadata<T>(url: URL): Promise<OrderedCollection<T>> {
 	const res = await fetch(url, { headers })
 	if (!res.ok) {
 		throw new Error(`${url} returned ${res.status}`)
@@ -28,7 +28,7 @@ export async function getMetadata<T extends ApObject>(url: URL): Promise<Ordered
 	return res.json<OrderedCollection<T>>()
 }
 
-export async function loadItems<T extends ApObject>(collection: OrderedCollection<T>, max?: number): Promise<Array<T>> {
+export async function loadItems<T>(collection: OrderedCollection<T>, max?: number): Promise<Array<T>> {
 	const items = []
 	let pageUrl = collection.first
 

--- a/backend/src/activitypub/objects/index.ts
+++ b/backend/src/activitypub/objects/index.ts
@@ -8,7 +8,6 @@ export const originalObjectIdSymbol = Symbol()
 export const mastodonIdSymbol = Symbol()
 
 export type Remote<T extends ApObject> = Omit<ApObject & Partial<Intersect<ApObject, T>>, symbol>
-export type Local<T extends ApObject> = T & Required<Pick<T, Extract<keyof T, symbol>>>
 
 // https://www.w3.org/TR/activitystreams-vocabulary/#object-types
 export interface ApObject {

--- a/backend/src/activitypub/objects/index.ts
+++ b/backend/src/activitypub/objects/index.ts
@@ -1,11 +1,14 @@
 import { addPeer } from 'wildebeest/backend/src/activitypub/peers'
 import { type Database } from 'wildebeest/backend/src/database'
 import type { MastodonID } from 'wildebeest/backend/src/types'
-import { RequiredProps, SingleOrArray } from 'wildebeest/backend/src/utils/type'
+import { Intersect, RequiredProps, SingleOrArray } from 'wildebeest/backend/src/utils/type'
 
 export const originalActorIdSymbol = Symbol()
 export const originalObjectIdSymbol = Symbol()
 export const mastodonIdSymbol = Symbol()
+
+export type Remote<T extends ApObject> = Omit<ApObject & Partial<Intersect<ApObject, T>>, symbol>
+export type Local<T extends ApObject> = T & Required<Pick<T, Extract<keyof T, symbol>>>
 
 // https://www.w3.org/TR/activitystreams-vocabulary/#object-types
 export interface ApObject {

--- a/backend/src/activitypub/objects/index.ts
+++ b/backend/src/activitypub/objects/index.ts
@@ -1,6 +1,6 @@
 import { addPeer } from 'wildebeest/backend/src/activitypub/peers'
 import { type Database } from 'wildebeest/backend/src/database'
-import type { UUID } from 'wildebeest/backend/src/types'
+import type { MastodonID } from 'wildebeest/backend/src/types'
 import { KeyTypeOf, RequiredProps, SingleOrArray } from 'wildebeest/backend/src/utils/type'
 
 export const originalActorIdSymbol = Symbol()
@@ -33,7 +33,7 @@ export interface ApObject {
 	// Internal
 	[originalActorIdSymbol]?: string
 	[originalObjectIdSymbol]?: string
-	[mastodonIdSymbol]?: UUID
+	[mastodonIdSymbol]?: MastodonID
 }
 
 export type ApObjectId = KeyTypeOf<ApObject, 'id'>
@@ -245,7 +245,7 @@ export async function getObjectByOriginalId(db: Database, id: string | URL): Pro
 	return getObjectBy(db, ObjectByKey.originalObjectId, id.toString())
 }
 
-export async function getObjectByMastodonId(db: Database, id: UUID): Promise<ApObject | null> {
+export async function getObjectByMastodonId(db: Database, id: MastodonID): Promise<ApObject | null> {
 	return getObjectBy(db, ObjectByKey.mastodonId, id)
 }
 

--- a/backend/src/activitypub/objects/index.ts
+++ b/backend/src/activitypub/objects/index.ts
@@ -1,7 +1,7 @@
 import { addPeer } from 'wildebeest/backend/src/activitypub/peers'
 import { type Database } from 'wildebeest/backend/src/database'
 import type { MastodonID } from 'wildebeest/backend/src/types'
-import { KeyTypeOf, RequiredProps, SingleOrArray } from 'wildebeest/backend/src/utils/type'
+import { RequiredProps, SingleOrArray } from 'wildebeest/backend/src/utils/type'
 
 export const originalActorIdSymbol = Symbol()
 export const originalObjectIdSymbol = Symbol()
@@ -36,8 +36,8 @@ export interface ApObject {
 	[mastodonIdSymbol]?: MastodonID
 }
 
-export type ApObjectId = KeyTypeOf<ApObject, 'id'>
-export type ApObjectUrl = NonNullable<KeyTypeOf<ApObject, 'url'>>
+export type ApObjectId = ApObject['id']
+export type ApObjectUrl = NonNullable<ApObject['url']>
 export type ApObjectOrId = ApObject | ApObjectId
 export type ApObjectOrUrl = ApObject | ApObjectUrl
 

--- a/backend/src/activitypub/objects/index.ts
+++ b/backend/src/activitypub/objects/index.ts
@@ -1,6 +1,6 @@
 import { addPeer } from 'wildebeest/backend/src/activitypub/peers'
 import { type Database } from 'wildebeest/backend/src/database'
-import type { MastodonID } from 'wildebeest/backend/src/types'
+import type { MastodonId } from 'wildebeest/backend/src/types'
 import { Intersect, RequiredProps, SingleOrArray } from 'wildebeest/backend/src/utils/type'
 
 export const originalActorIdSymbol = Symbol()
@@ -36,7 +36,7 @@ export interface ApObject {
 	// Internal
 	[originalActorIdSymbol]?: string
 	[originalObjectIdSymbol]?: string
-	[mastodonIdSymbol]?: MastodonID
+	[mastodonIdSymbol]?: MastodonId
 }
 
 export type ApObjectId = ApObject['id']
@@ -248,7 +248,7 @@ export async function getObjectByOriginalId(db: Database, id: string | URL): Pro
 	return getObjectBy(db, ObjectByKey.originalObjectId, id.toString())
 }
 
-export async function getObjectByMastodonId(db: Database, id: MastodonID): Promise<ApObject | null> {
+export async function getObjectByMastodonId(db: Database, id: MastodonId): Promise<ApObject | null> {
 	return getObjectBy(db, ObjectByKey.mastodonId, id)
 }
 

--- a/backend/src/mastodon/account.ts
+++ b/backend/src/mastodon/account.ts
@@ -1,6 +1,6 @@
 import { Actor } from 'wildebeest/backend/src/activitypub/actors'
-import * as apFollow from 'wildebeest/backend/src/activitypub/actors/follow'
-import * as apOutbox from 'wildebeest/backend/src/activitypub/actors/outbox'
+import { countFollowers, countFollowing } from 'wildebeest/backend/src/activitypub/actors/follow'
+import { countStatuses } from 'wildebeest/backend/src/activitypub/actors/outbox'
 import { mastodonIdSymbol } from 'wildebeest/backend/src/activitypub/objects'
 import { type Database } from 'wildebeest/backend/src/database'
 import type { MastodonAccount, Preference } from 'wildebeest/backend/src/types/account'
@@ -54,63 +54,105 @@ function toMastodonAccount(
 
 // Load an external user, using ActivityPub queries, and return it as a MastodonAccount
 export async function loadExternalMastodonAccount(
+	db: Database,
 	actor: Actor,
-	loadStats = false,
-	handle?: RemoteHandle
+	handle?: RemoteHandle,
+	loadStat = false
 ): Promise<MastodonAccount> {
 	if (handle === undefined) {
 		handle = actorToHandle(actor)
 	}
+	const { results } = await db
+		.prepare(
+			`
+SELECT outbox_objects.published_date as last_status_at
+FROM outbox_objects
+INNER JOIN objects ON objects.id = outbox_objects.object_id
+WHERE outbox_objects.actor_id=?
+  AND objects.type = 'Note'
+ORDER BY strftime('%Y-%m-%d %H:%M:%f', outbox_objects.published_date) DESC
+LIMIT 1
+  `
+		)
+		.bind(actor.id.toString())
+		.all<{ last_status_at: string }>()
+
+	const lastStatusAt =
+		results !== undefined && results.length === 1 ? new Date(results[0].last_status_at).toISOString() : null
+
 	const account = toMastodonAccount(handle, actor)
-	if (loadStats === true) {
-		account.statuses_count = await apOutbox.countStatuses(actor)
-		account.followers_count = await apFollow.countFollowers(actor)
-		account.following_count = await apFollow.countFollowing(actor)
+	if (loadStat) {
+		return {
+			...account,
+			// TODO: cache this
+			statuses_count: await countStatuses(actor),
+			followers_count: await countFollowers(actor),
+			following_count: await countFollowing(actor),
+			last_status_at: lastStatusAt,
+		}
 	}
-	return account
+	return {
+		...account,
+		statuses_count: 0,
+		followers_count: 0,
+		following_count: 0,
+		last_status_at: lastStatusAt,
+	}
 }
 
 // Load a local user and return it as a MastodonAccount
 export async function loadLocalMastodonAccount(
 	db: Database,
-	res: Actor,
+	actor: Actor,
 	handle?: LocalHandle
 ): Promise<MastodonAccount> {
 	if (handle === undefined) {
 		handle = {
-			localPart: actorToHandle(res).localPart,
+			localPart: actorToHandle(actor).localPart,
 			domain: null,
 		}
 	}
-	const account = toMastodonAccount(handle, res)
+	const account = toMastodonAccount(handle, actor)
 
 	const query = `
 SELECT
   (SELECT count(*)
    FROM outbox_objects
    INNER JOIN objects ON objects.id = outbox_objects.object_id
-   WHERE outbox_objects.actor_id=?
+   WHERE outbox_objects.actor_id=?1
      AND objects.type = 'Note') AS statuses_count,
 
   (SELECT count(*)
    FROM actor_following
-   WHERE actor_following.actor_id=?) AS following_count,
+   WHERE actor_following.actor_id=?1) AS following_count,
 
   (SELECT count(*)
    FROM actor_following
-   WHERE actor_following.target_actor_id=?) AS followers_count
+   WHERE actor_following.target_actor_id=?1) AS followers_count,
+
+  (SELECT outbox_objects.published_date
+   FROM outbox_objects
+   INNER JOIN objects ON objects.id = outbox_objects.object_id
+   WHERE outbox_objects.actor_id=?1
+     AND objects.type = 'Note'
+   ORDER BY strftime('%Y-%m-%d %H:%M:%f', outbox_objects.published_date) DESC
+   LIMIT 1) as last_status_at
   `
 
-	const row = await db
-		.prepare(query)
-		.bind(res.id.toString(), res.id.toString(), res.id.toString())
-		.first<{ statuses_count: number; followers_count: number; following_count: number }>()
+	const row = await db.prepare(query).bind(actor.id.toString()).first<{
+		statuses_count: number
+		followers_count: number
+		following_count: number
+		last_status_at: string | null
+	}>()
 
-	account.statuses_count = row.statuses_count
-	account.followers_count = row.followers_count
-	account.following_count = row.following_count
-
-	return account
+	return {
+		...account,
+		statuses_count: row.statuses_count,
+		followers_count: row.followers_count,
+		following_count: row.following_count,
+		last_status_at: row.last_status_at === null ? null : new Date(row.last_status_at).toISOString(),
+	}
 }
 
 export async function getSigningKey(instanceKey: string, db: Database, actor: Actor): Promise<CryptoKey> {

--- a/backend/src/mastodon/account.ts
+++ b/backend/src/mastodon/account.ts
@@ -13,11 +13,15 @@ import {
 	RemoteHandle,
 } from 'wildebeest/backend/src/utils/handle'
 import { unwrapPrivateKey } from 'wildebeest/backend/src/utils/key-ops'
+import { PartialProps } from 'wildebeest/backend/src/utils/type'
 import { defaultImages } from 'wildebeest/config/accounts'
 
-function toMastodonAccount(handle: Handle, res: Actor): MastodonAccount {
-	const avatar = res.icon?.url?.toString() ?? defaultImages.avatar
-	const header = res.image?.url?.toString() ?? defaultImages.header
+function toMastodonAccount(
+	handle: Handle,
+	actor: Actor
+): PartialProps<MastodonAccount, 'last_status_at' | 'followers_count' | 'following_count' | 'statuses_count'> {
+	const avatar = actor.icon?.url?.toString() ?? defaultImages.avatar
+	const header = actor.image?.url?.toString() ?? defaultImages.header
 
 	let acct: string
 	if (isLocalHandle(handle)) {
@@ -26,33 +30,25 @@ function toMastodonAccount(handle: Handle, res: Actor): MastodonAccount {
 		acct = handleToAcct(handle)
 	}
 
-	// TODO: replace stubs with actual values
 	return {
+		id: actor[mastodonIdSymbol],
+		username: actor.preferredUsername ?? actor.name ?? 'unnamed',
 		acct,
-		id: res[mastodonIdSymbol],
-		username: res.preferredUsername || res.name || 'unnamed',
-		url: res.url ? res.url.toString() : '',
-		display_name: res.name || res.preferredUsername || '',
-		note: res.summary || '',
-		created_at: res.published || new Date().toISOString(),
-
+		url: actor.url ? actor.url.toString() : '',
+		display_name: actor.name ?? actor.preferredUsername ?? '',
+		note: actor.summary ?? '',
 		avatar,
 		avatar_static: avatar,
-
 		header,
 		header_static: header,
-
-		locked: false,
-		bot: false,
-		discoverable: true,
-		group: false,
-
-		emojis: [],
+		locked: actor.manuallyApprovesFollowers ?? false,
+		// TODO: replace stubs with actual values
 		fields: [],
-
-		followers_count: 0,
-		following_count: 0,
-		statuses_count: 0,
+		emojis: [],
+		bot: actor.type === 'Service',
+		group: actor.type === 'Group',
+		discoverable: actor.discoverable,
+		created_at: actor.published ?? new Date().toISOString(),
 	}
 }
 

--- a/backend/src/mastodon/account.ts
+++ b/backend/src/mastodon/account.ts
@@ -78,8 +78,14 @@ export async function loadExternalMastodonAccount(
 export async function loadLocalMastodonAccount(
 	db: Database,
 	res: Actor,
-	handle: LocalHandle
+	handle?: LocalHandle
 ): Promise<MastodonAccount> {
+	if (handle === undefined) {
+		handle = {
+			localPart: actorToHandle(res).localPart,
+			domain: null,
+		}
+	}
 	const account = toMastodonAccount(handle, res)
 
 	const query = `

--- a/backend/src/mastodon/account.ts
+++ b/backend/src/mastodon/account.ts
@@ -1,6 +1,7 @@
 import { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import * as apFollow from 'wildebeest/backend/src/activitypub/actors/follow'
 import * as apOutbox from 'wildebeest/backend/src/activitypub/actors/outbox'
+import { mastodonIdSymbol } from 'wildebeest/backend/src/activitypub/objects'
 import { type Database } from 'wildebeest/backend/src/database'
 import type { MastodonAccount, Preference } from 'wildebeest/backend/src/types/account'
 import {
@@ -25,11 +26,10 @@ function toMastodonAccount(handle: Handle, res: Actor): MastodonAccount {
 		acct = handleToAcct(handle)
 	}
 
+	// TODO: replace stubs with actual values
 	return {
 		acct,
-
-		// FIXME: use numeric id
-		id: acct,
+		id: res[mastodonIdSymbol],
 		username: res.preferredUsername || res.name || 'unnamed',
 		url: res.url ? res.url.toString() : '',
 		display_name: res.name || res.preferredUsername || '',

--- a/backend/src/mastodon/notification.ts
+++ b/backend/src/mastodon/notification.ts
@@ -241,7 +241,7 @@ export async function getNotifications(db: Database, actor: Actor, domain: strin
 			continue
 		}
 
-		const notifFromAccount = await loadExternalMastodonAccount(notifFromActor)
+		const notifFromAccount = await loadExternalMastodonAccount(db, notifFromActor)
 
 		const notif: Notification = {
 			id: result.notif_id.toString(),
@@ -253,7 +253,7 @@ export async function getNotifications(db: Database, actor: Actor, domain: strin
 		if (result.type === 'mention' || result.type === 'favourite') {
 			const actorId = new URL(result.original_actor_id)
 			const actor = await actors.getAndCache(actorId, db)
-			const account = await loadExternalMastodonAccount(actor)
+			const account = await loadExternalMastodonAccount(db, actor)
 
 			notif.status = {
 				id: result.mastodon_id,

--- a/backend/src/mastodon/reply.ts
+++ b/backend/src/mastodon/reply.ts
@@ -23,8 +23,12 @@ export async function getReplies(domain: string, db: Database, obj: ApObject): P
 	const QUERY = `
 SELECT objects.*,
        actors.id as actor_id,
+       actors.type as actor_type,
+       actors.pubkey as actor_pubkey,
        actors.cdate as actor_cdate,
        actors.properties as actor_properties,
+       actors.is_admin as actor_is_admin,
+       actors.mastodon_id as actor_mastodon_id,
        actor_replies.actor_id as publisher_actor_id,
        (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
        (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
@@ -38,7 +42,23 @@ LIMIT ?
 `
 	const DEFAULT_LIMIT = 20
 
-	const { success, error, results } = await db.prepare(QUERY).bind(obj.id.toString(), DEFAULT_LIMIT).all()
+	const { success, error, results } = await db.prepare(QUERY).bind(obj.id.toString(), DEFAULT_LIMIT).all<{
+		mastodon_id: string
+		id: string
+		cdate: string
+		properties: string
+		actor_id: string
+		actor_type: Actor['type']
+		actor_pubkey: string | null
+		actor_cdate: string
+		actor_properties: string
+		actor_is_admin: 1 | null
+		actor_mastodon_id: string
+		publisher_actor_id: string
+		favourites_count: number
+		reblogs_count: number
+		replies_count: number
+	}>()
 	if (!success) {
 		throw new Error('SQL error: ' + error)
 	}

--- a/backend/src/mastodon/status.ts
+++ b/backend/src/mastodon/status.ts
@@ -13,7 +13,7 @@ import { createPublicNote, type Note } from 'wildebeest/backend/src/activitypub/
 import { type Database } from 'wildebeest/backend/src/database'
 import { loadExternalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
 import * as media from 'wildebeest/backend/src/media/'
-import type { UUID } from 'wildebeest/backend/src/types'
+import type { MastodonID } from 'wildebeest/backend/src/types'
 import type { MastodonStatus } from 'wildebeest/backend/src/types'
 import type { MediaAttachment } from 'wildebeest/backend/src/types/media'
 import { handleToAcct, parseHandle, toRemoteHandle } from 'wildebeest/backend/src/utils/handle'
@@ -179,7 +179,11 @@ export async function toMastodonStatusFromRow(domain: string, db: Database, row:
 	return status
 }
 
-export async function getMastodonStatusById(db: Database, id: UUID, domain: string): Promise<MastodonStatus | null> {
+export async function getMastodonStatusById(
+	db: Database,
+	id: MastodonID,
+	domain: string
+): Promise<MastodonStatus | null> {
 	const obj = await getObjectByMastodonId(db, id)
 	if (obj === null) {
 		return null

--- a/backend/src/mastodon/status.ts
+++ b/backend/src/mastodon/status.ts
@@ -57,7 +57,7 @@ export async function toMastodonStatusFromObject(
 	const actorId = new URL(obj[originalActorIdSymbol])
 	const actor = await actors.getAndCache(actorId, db)
 
-	const account = await loadExternalMastodonAccount(actor)
+	const account = await loadExternalMastodonAccount(db, actor)
 
 	// FIXME: temporarly disable favourites and reblogs counts
 	const favourites = []
@@ -147,7 +147,7 @@ export async function toMastodonStatusFromRow(
 		mastodon_id: row.actor_mastodon_id,
 	})
 
-	const account = await loadExternalMastodonAccount(author)
+	const account = await loadExternalMastodonAccount(db, author)
 
 	if (row.favourites_count === undefined || row.reblogs_count === undefined || row.replies_count === undefined) {
 		throw new Error('logic error; missing fields.')
@@ -196,7 +196,7 @@ export async function toMastodonStatusFromRow(
 
 		const actorId = new URL(properties.attributedTo)
 		const author = await actors.getAndCache(actorId, db)
-		const account = await loadExternalMastodonAccount(author)
+		const account = await loadExternalMastodonAccount(db, author)
 
 		// Restore reblogged status
 		status.reblog = {

--- a/backend/src/mastodon/status.ts
+++ b/backend/src/mastodon/status.ts
@@ -13,7 +13,7 @@ import { createPublicNote, type Note } from 'wildebeest/backend/src/activitypub/
 import { type Database } from 'wildebeest/backend/src/database'
 import { loadExternalMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
 import * as media from 'wildebeest/backend/src/media/'
-import type { MastodonID } from 'wildebeest/backend/src/types'
+import type { MastodonId } from 'wildebeest/backend/src/types'
 import type { MastodonStatus } from 'wildebeest/backend/src/types'
 import type { MediaAttachment } from 'wildebeest/backend/src/types/media'
 import { handleToAcct, parseHandle, toRemoteHandle } from 'wildebeest/backend/src/utils/handle'
@@ -181,7 +181,7 @@ export async function toMastodonStatusFromRow(domain: string, db: Database, row:
 
 export async function getMastodonStatusById(
 	db: Database,
-	id: MastodonID,
+	id: MastodonId,
 	domain: string
 ): Promise<MastodonStatus | null> {
 	const obj = await getObjectByMastodonId(db, id)

--- a/backend/src/middleware/error.ts
+++ b/backend/src/middleware/error.ts
@@ -6,7 +6,7 @@ import { internalServerError } from '../errors'
 /**
  * A Pages middleware function that logs errors to the console and responds with 500 errors and stack-traces.
  */
-export async function errorHandling(context: EventContext<Env, any, any>) {
+export async function errorHandling(context: EventContext<Env, string, unknown>) {
 	const sentry = initSentry(context.request, context.env, context)
 
 	try {

--- a/backend/src/middleware/main.ts
+++ b/backend/src/middleware/main.ts
@@ -1,17 +1,31 @@
 import * as access from 'wildebeest/backend/src/access'
-import * as actors from 'wildebeest/backend/src/activitypub/actors'
+import { actorFromRow, ActorRow, PERSON, Person, setMastodonId } from 'wildebeest/backend/src/activitypub/actors'
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
 import * as errors from 'wildebeest/backend/src/errors'
+import { ContextData } from 'wildebeest/backend/src/types/context'
 import type { Env } from 'wildebeest/backend/src/types/env'
 import { cors } from 'wildebeest/backend/src/utils/cors'
 
-async function loadContextData(db: Database, clientId: string, email: string, ctx: any): Promise<boolean> {
+async function loadContextData(
+	db: Database,
+	clientId: string,
+	email: string,
+	ctx: { data: Partial<ContextData> }
+): Promise<boolean> {
 	const query = `
         SELECT *
         FROM actors
         WHERE email=? AND type='Person'
     `
-	const { results, success, error } = await db.prepare(query).bind(email).all()
+	const { results, success, error } = await db.prepare(query).bind(email).all<{
+		id: string
+		type: typeof PERSON
+		pubkey: string
+		cdate: string
+		properties: string
+		is_admin: 1 | null
+		mastodon_id: string | null
+	}>()
 	if (!success) {
 		throw new Error('SQL error: ' + error)
 	}
@@ -21,14 +35,17 @@ async function loadContextData(db: Database, clientId: string, email: string, ct
 		return false
 	}
 
-	const row: any = results[0]
+	const row: ActorRow<Person> = {
+		...results[0],
+		mastodon_id: results[0].mastodon_id || (await setMastodonId(db, results[0].id, results[0].cdate)),
+	}
 
 	if (!row.id) {
 		console.warn('person not found')
 		return false
 	}
 
-	const actor = actors.actorFromRow(row)
+	const actor = actorFromRow(row)
 
 	ctx.data.connectedActor = actor
 	ctx.data.identity = { email }
@@ -37,7 +54,7 @@ async function loadContextData(db: Database, clientId: string, email: string, ct
 	return true
 }
 
-export async function main(context: EventContext<Env, any, any>) {
+export async function main(context: EventContext<Env, string, Partial<ContextData>>) {
 	if (context.request.method === 'OPTIONS') {
 		const headers = {
 			...cors(),

--- a/backend/src/middleware/main.ts
+++ b/backend/src/middleware/main.ts
@@ -81,6 +81,7 @@ export async function main(context: EventContext<Env, string, Partial<ContextDat
 		/^\/api\/v1\/accounts\/(.*)\/statuses$/.test(url.pathname) ||
 		url.pathname.startsWith('/api/v1/tags/') ||
 		url.pathname.startsWith('/api/v1/timelines/tag/') ||
+		url.pathname.startsWith('/api/v1/accounts/lookup') ||
 		url.pathname.startsWith('/ap/') // all ActivityPub endpoints
 	) {
 		return context.next()

--- a/backend/src/types/account.ts
+++ b/backend/src/types/account.ts
@@ -7,26 +7,25 @@ export interface MastodonAccount {
 	url: string
 	display_name: string
 	note: string
-
 	avatar: string
 	avatar_static: string
-
 	header: string
 	header_static: string
-
+	locked: boolean
+	fields: Array<Field>
+	emojis: Array<CustomEmoji>
+	bot: boolean
+	group: boolean
+	discoverable: boolean | null
+	noindex?: boolean | null
+	moved?: MastodonAccount | null
+	suspended?: boolean
+	limited?: boolean
 	created_at: string
-
-	locked?: boolean
-	bot?: boolean
-	discoverable?: boolean
-	group?: boolean
-
+	last_status_at: string | null
+	statuses_count: number
 	followers_count: number
 	following_count: number
-	statuses_count: number
-
-	emojis: Array<any>
-	fields: Array<Field>
 }
 
 // https://docs.joinmastodon.org/entities/Relationship/
@@ -77,4 +76,12 @@ export type Preference = {
 	posting_default_language: string | null
 	reading_expand_media: ReadingExpandMedia
 	reading_expand_spoilers: boolean
+}
+
+export type CustomEmoji = {
+	shortcode: string
+	url: string
+	static_url: string
+	visible_in_picker: boolean
+	category: string
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,4 +1,4 @@
 export * from './account'
 export * from './status'
 
-export type UUID = string
+export type MastodonID = string

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,4 +1,4 @@
 export * from './account'
 export * from './status'
 
-export type MastodonID = string
+export type MastodonId = string

--- a/backend/src/types/status.ts
+++ b/backend/src/types/status.ts
@@ -1,4 +1,4 @@
-import type { MastodonID } from 'wildebeest/backend/src/types'
+import type { MastodonId } from 'wildebeest/backend/src/types'
 
 import type { MastodonAccount } from './account'
 import type { MediaAttachment } from './media'
@@ -8,7 +8,7 @@ export type Visibility = 'public' | 'unlisted' | 'private' | 'direct'
 // https://docs.joinmastodon.org/entities/Status/
 // https://github.com/mastodon/mastodon-android/blob/master/mastodon/src/main/java/org/joinmastodon/android/model/Status.java
 export type MastodonStatus = {
-	id: MastodonID
+	id: MastodonId
 	uri: URL
 	url: URL
 	created_at: string

--- a/backend/src/types/status.ts
+++ b/backend/src/types/status.ts
@@ -1,4 +1,4 @@
-import type { UUID } from 'wildebeest/backend/src/types'
+import type { MastodonID } from 'wildebeest/backend/src/types'
 
 import type { MastodonAccount } from './account'
 import type { MediaAttachment } from './media'
@@ -8,7 +8,7 @@ export type Visibility = 'public' | 'unlisted' | 'private' | 'direct'
 // https://docs.joinmastodon.org/entities/Status/
 // https://github.com/mastodon/mastodon-android/blob/master/mastodon/src/main/java/org/joinmastodon/android/model/Status.java
 export type MastodonStatus = {
-	id: UUID
+	id: MastodonID
 	uri: URL
 	url: URL
 	created_at: string

--- a/backend/src/utils/auth/getAdmins.ts
+++ b/backend/src/utils/auth/getAdmins.ts
@@ -1,25 +1,41 @@
-import { actorFromRow, Person } from 'wildebeest/backend/src/activitypub/actors'
+import { actorFromRow, ActorRow, PERSON, Person } from 'wildebeest/backend/src/activitypub/actors'
 import { type Database } from 'wildebeest/backend/src/database'
 
 export async function getAdmins(db: Database): Promise<Person[]> {
-	let rows: unknown[] = []
 	try {
-		const stmt = db.prepare('SELECT * FROM actors WHERE is_admin=1')
-		const result = await stmt.all<unknown>()
-		rows = result.success ? (result.results as unknown[]) : []
+		const stmt = db.prepare('SELECT * FROM actors WHERE is_admin=1 AND type=?').bind(PERSON)
+		const { success, results } = await stmt.all<{
+			id: string
+			type: Person['type']
+			pubkey: string | null
+			cdate: string
+			properties: string
+			is_admin: 1
+			mastodon_id: string
+		}>()
+		if (success && results !== undefined) {
+			return results.map((row: ActorRow<Person>) => actorFromRow(row))
+		}
 	} catch {
 		/* empty */
 	}
-
-	return rows.map(actorFromRow) as Person[]
+	return []
 }
 
 export async function getAdminByEmail(db: Database, email: string): Promise<Person | null> {
-	const stmt = db.prepare('SELECT * FROM actors WHERE email=? AND is_admin=1 AND type=?').bind(email, 'Person') // TODO: use constant
-	const { results } = await stmt.all()
+	const stmt = db.prepare('SELECT * FROM actors WHERE email=? AND is_admin=1 AND type=?').bind(email, PERSON)
+	const { results } = await stmt.all<{
+		id: string
+		type: Person['type']
+		pubkey: string | null
+		cdate: string
+		properties: string
+		is_admin: 1
+		mastodon_id: string
+	}>()
 	if (!results || results.length === 0) {
 		return null
 	}
-	const row: any = results[0]
-	return actorFromRow(row) as Person
+	const row: ActorRow<Person> = results[0]
+	return actorFromRow(row)
 }

--- a/backend/src/utils/handle.ts
+++ b/backend/src/utils/handle.ts
@@ -77,3 +77,7 @@ export function actorToHandle(actor: Actor): RemoteHandle {
 export function handleToAcct(handle: RemoteHandle): string {
 	return `${handle.localPart}@${handle.domain}`
 }
+
+export function handleToUrl(handle: RemoteHandle): URL {
+	return new URL('@' + handle.localPart, 'https://' + handle.domain)
+}

--- a/backend/src/utils/handle.ts
+++ b/backend/src/utils/handle.ts
@@ -1,19 +1,14 @@
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import { getApId } from 'wildebeest/backend/src/activitypub/objects'
 
-const remoteHandleSymbol = Symbol()
-const localHandleSymbol = Symbol()
-
 export type RemoteHandle = {
 	localPart: string
 	domain: string
-	[remoteHandleSymbol]: never
 }
 
 export type LocalHandle = {
 	localPart: string
-	domain: string | null
-	[localHandleSymbol]: never
+	domain: null
 }
 
 export type Handle = LocalHandle | RemoteHandle

--- a/backend/src/utils/id.ts
+++ b/backend/src/utils/id.ts
@@ -1,0 +1,47 @@
+import type { Database } from 'wildebeest/backend/src/database'
+import { MastodonId } from 'wildebeest/backend/src/types'
+
+export async function generateMastodonId(db: Database, table: string, now: Date): Promise<MastodonId> {
+	if (now === undefined) {
+		now = new Date()
+	}
+	const timePart = BigInt(now.getTime()) << 16n
+
+	const digest = await crypto.subtle.digest(
+		{ name: 'MD5' },
+		new TextEncoder().encode(table + randomBytes(16) + String(timePart))
+	)
+	const hash = bytesToHex(new Uint8Array(digest))
+
+	const sequenceBase = BigInt('0x' + hash.substring(0, 4))
+	const tail = (sequenceBase + BigInt(await nextval(db, table))) & 65535n
+
+	return String(timePart | tail)
+}
+
+function randomBytes(length: number): string {
+	const buffer = new Uint8Array(length)
+	crypto.getRandomValues(buffer)
+	return bytesToHex(buffer)
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+	return [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+async function nextval(db: Database, table: string): Promise<number> {
+	const key = table + '_id_seq'
+	const row = await db
+		.prepare(
+			`
+INSERT INTO id_sequences (key, value)
+VALUES (?1, COALESCE((SELECT value FROM id_sequences WHERE key = ?1), 0) + 1)
+ON CONFLICT(key) DO UPDATE SET value = excluded.value
+RETURNING value;
+`
+		)
+		.bind(key)
+		.first<{ value: number }>()
+
+	return row.value
+}

--- a/backend/src/utils/sentry.ts
+++ b/backend/src/utils/sentry.ts
@@ -1,7 +1,7 @@
 import { Toucan } from 'toucan-js'
 import type { Env } from 'wildebeest/backend/src/types/env'
 
-export function initSentry(request: Request, env: Env, context: any) {
+export function initSentry(request: Request, env: Env, context: { waitUntil: ExecutionContext['waitUntil'] }) {
 	if (env.SENTRY_DSN === '') {
 		return null
 	}

--- a/backend/src/utils/type.ts
+++ b/backend/src/utils/type.ts
@@ -1,4 +1,3 @@
-export type KeyTypeOf<T, K extends keyof T> = { [P in K]: T[P] }[K]
 export type SingleOrArray<T> = T | T[]
 export type RequiredProps<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 export type NonNullableProps<T, K extends keyof T> = Omit<T, K> & { [P in K]: NonNullable<T[P]> }

--- a/backend/src/utils/type.ts
+++ b/backend/src/utils/type.ts
@@ -1,6 +1,7 @@
 export type SingleOrArray<T> = T | T[]
 export type RequiredProps<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 export type NonNullableProps<T, K extends keyof T> = Omit<T, K> & { [P in K]: NonNullable<T[P]> }
+export type PartialProps<T, K extends keyof T> = Omit<T, K> & { [P in K]?: T[P] }
 
 export type Intersect<T, U> = Exclude<keyof T, keyof U> extends never
 	? Exclude<keyof U, keyof T> extends never

--- a/backend/src/utils/type.ts
+++ b/backend/src/utils/type.ts
@@ -1,3 +1,9 @@
 export type SingleOrArray<T> = T | T[]
 export type RequiredProps<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 export type NonNullableProps<T, K extends keyof T> = Omit<T, K> & { [P in K]: NonNullable<T[P]> }
+
+export type Intersect<T, U> = Exclude<keyof T, keyof U> extends never
+	? Exclude<keyof U, keyof T> extends never
+		? never
+		: { [P in Exclude<keyof U, keyof T>]: U[P] }
+	: { [P in Exclude<keyof T, keyof U>]: T[P] }

--- a/backend/test/activitypub.spec.ts
+++ b/backend/test/activitypub.spec.ts
@@ -35,6 +35,7 @@ describe('ActivityPub', () => {
 		test('fetch user by id', async () => {
 			const db = await makeDB()
 			const properties = {
+				discoverable: true,
 				summary: 'test summary',
 				inbox: 'https://example.com/inbox',
 				outbox: 'https://example.com/outbox',

--- a/backend/test/activitypub.spec.ts
+++ b/backend/test/activitypub.spec.ts
@@ -83,7 +83,7 @@ describe('ActivityPub', () => {
 				throw new Error('unexpected request to ' + input.url)
 			}
 
-			const actor = await actors.get('https://example.com/actor')
+			const actor = await actors.fetchActor('https://example.com/actor')
 			assert.equal(actor.summary, "it's me, Mario. <p>alert(1)</p>")
 			assert.equal(actor.name, 'hi hey')
 			assert.equal(actor.preferredUsername, 'sven alert(1)')
@@ -108,7 +108,7 @@ describe('ActivityPub', () => {
 				throw new Error('unexpected request to ' + input.url)
 			}
 
-			const actor = await actors.get('https://example.com/actor')
+			const actor = await actors.fetchActor('https://example.com/actor')
 			assert.equal(actor.summary, 'a'.repeat(500))
 			assert.equal(actor.name, 'b'.repeat(30))
 			assert.equal(actor.preferredUsername, 'c'.repeat(30))

--- a/backend/test/mastodon.spec.ts
+++ b/backend/test/mastodon.spec.ts
@@ -75,10 +75,10 @@ describe('Mastodon APIs', () => {
 				assert.equal(data.configuration.polls.max_expiration, 2629746)
 				assert.equal(data.contact_account!.acct, 'b')
 				assert.equal(data.contact_account!.display_name, 'b')
-				assert.equal(data.contact_account!.id, 'b')
 				assert.equal(data.contact_account!.username, 'b')
 				assert.equal(data.contact_account!.url, 'https://cloudflare.com/@b')
 				assert.equal(data.rules.length, 0)
+				assert.ok(data.contact_account!.id)
 			}
 		})
 
@@ -157,10 +157,10 @@ describe('Mastodon APIs', () => {
 				assert.equal(data.contact.email, 'b')
 				assert.equal(data.contact.account!.acct, 'b')
 				assert.equal(data.contact.account!.display_name, 'b')
-				assert.equal(data.contact.account!.id, 'b')
 				assert.equal(data.contact.account!.username, 'b')
 				assert.equal(data.contact.account!.url, 'https://cloudflare.com/@b')
 				assert.equal(data.rules.length, 0)
+				assert.ok(data.contact.account!.id)
 			}
 		})
 	})

--- a/backend/test/mastodon/accounts.spec.ts
+++ b/backend/test/mastodon/accounts.spec.ts
@@ -227,15 +227,13 @@ describe('Mastodon APIs', () => {
 
 		test('lookup unknown remote actor', async () => {
 			const db = await makeDB()
-			const req = new Request(new URL('?acct=sven@social.com', 'https://' + domain))
-			const res = await lookup.handleRequest(req, db)
+			const res = await lookup.handleRequest({ domain, db }, 'sven@social.com')
 			assert.equal(res.status, 404)
 		})
 
 		test('lookup unknown local actor', async () => {
 			const db = await makeDB()
-			const req = new Request(new URL('?acct=sven', 'https://' + domain))
-			const res = await lookup.handleRequest(req, db)
+			const res = await lookup.handleRequest({ domain, db }, 'sven')
 			assert.equal(res.status, 404)
 		})
 
@@ -314,8 +312,7 @@ describe('Mastodon APIs', () => {
 
 			const db = await makeDB()
 			await queryAcct({ localPart: 'someone', domain: 'social.com' }, db)
-			const req = new Request('https://' + domain + '?acct=someone@social.com')
-			const res = await lookup.handleRequest(req, db)
+			const res = await lookup.handleRequest({ domain, db }, 'someone@social.com')
 			assert.equal(res.status, 200)
 
 			const data = await res.json<any>()
@@ -345,8 +342,7 @@ describe('Mastodon APIs', () => {
 
 			await createStatus(domain, db, actor, 'my first status')
 
-			const req = new Request('https://' + domain + '?acct=sven')
-			const res = await lookup.handleRequest(req, db)
+			const res = await lookup.handleRequest({ domain, db }, 'sven')
 			assert.equal(res.status, 200)
 
 			const data = await res.json<any>()

--- a/backend/test/mastodon/search.spec.ts
+++ b/backend/test/mastodon/search.spec.ts
@@ -114,7 +114,7 @@ describe('Mastodon APIs', () => {
 			assert.equal(data.hashtags.length, 0)
 
 			const account = data.accounts[0]
-			assert.equal(account.id, 'sven@remote.com')
+			assert.ok(account.id)
 			assert.equal(account.username, 'sven')
 			assert.equal(account.acct, 'sven@remote.com')
 		})

--- a/backend/test/utils.ts
+++ b/backend/test/utils.ts
@@ -131,3 +131,12 @@ export async function generateVAPIDKeys(): Promise<JWK> {
 	const jwk = (await crypto.subtle.exportKey('jwk', keyPair.privateKey)) as JWK
 	return jwk
 }
+
+export function hexToBytes(hex: string): Uint8Array {
+	const bytes = new Uint8Array(Math.ceil(hex.length / 2))
+	for (let i = 0; i < bytes.length; i++) {
+		const start = i * 2
+		bytes[i] = parseInt(hex.substring(start, start + 2), 16)
+	}
+	return bytes
+}

--- a/frontend/mock-db/init.ts
+++ b/frontend/mock-db/init.ts
@@ -97,7 +97,7 @@ async function getOrCreatePerson(
 		'test-kek',
 		email,
 		{
-			icon: { url: avatar },
+			icon: { type: 'Image', id: avatar, url: avatar },
 			name: display_name,
 		},
 		isAdmin

--- a/frontend/src/routes/(frontend)/[accountId]/layout.tsx
+++ b/frontend/src/routes/(frontend)/[accountId]/layout.tsx
@@ -22,7 +22,7 @@ export const accountPageLoader = loader$<
 	try {
 		const url = new URL(request.url)
 		const domain = url.hostname
-		const accountId = url.pathname.split('/')[1]
+		const handle = url.pathname.split('/')[1]
 
 		try {
 			const statusResponse = await statusAPI.handleRequestGet(
@@ -37,7 +37,7 @@ export const accountPageLoader = loader$<
 			isValidStatus = false
 		}
 
-		account = await getAccount(domain, accountId, await getDatabase(platform))
+		account = await getAccount(domain, await getDatabase(platform), handle)
 	} catch {
 		throw html(
 			500,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,9 +1,9 @@
 {
 	"compilerOptions": {
 		"allowJs": true,
-		"target": "ES2017",
-		"module": "ES2020",
-		"lib": ["es2020", "DOM", "WebWorker", "DOM.Iterable"],
+		"target": "ES2021",
+		"module": "ES2022",
+		"lib": ["ES2021", "DOM", "WebWorker", "DOM.Iterable"],
 		"jsx": "react-jsx",
 		"jsxImportSource": "@builder.io/qwik",
 		"strict": true,
@@ -22,5 +22,5 @@
 			"wildebeest/*": ["../*"]
 		}
 	},
-	"include": ["src", "mock-db", "test", "adaptors","../backend/src", "../config", "../functions"]
+	"include": ["src", "mock-db", "test", "adaptors", "../backend/src", "../config", "../functions"]
 }

--- a/functions/api/v1/accounts/[id]/followers.ts
+++ b/functions/api/v1/accounts/[id]/followers.ts
@@ -41,7 +41,7 @@ async function getRemoteFollowers(handle: RemoteHandle, db: Database): Promise<R
 	const followers = await loadActors(db, followersIds)
 
 	const promises = followers.map((actor) => {
-		return loadExternalMastodonAccount(actor)
+		return loadExternalMastodonAccount(db, actor)
 	})
 
 	const out = await Promise.all(promises)
@@ -64,7 +64,7 @@ async function getLocalFollowers(domain: string, handle: LocalHandle, db: Databa
 
 		try {
 			const actor = await actors.getAndCache(id, db)
-			out.push(await loadExternalMastodonAccount(actor))
+			out.push(await loadExternalMastodonAccount(db, actor))
 		} catch (err: any) {
 			console.warn(`failed to retrieve follower (${id}): ${err.message}`)
 		}

--- a/functions/api/v1/accounts/[id]/following.ts
+++ b/functions/api/v1/accounts/[id]/following.ts
@@ -41,7 +41,7 @@ async function getRemoteFollowing(handle: RemoteHandle, db: Database): Promise<R
 	const following = await loadActors(db, followingIds)
 
 	const promises = following.map((actor) => {
-		return loadExternalMastodonAccount(actor)
+		return loadExternalMastodonAccount(db, actor)
 	})
 
 	const out = await Promise.all(promises)
@@ -64,7 +64,7 @@ async function getLocalFollowing(domain: string, handle: LocalHandle, db: Databa
 
 		try {
 			const actor = await actors.getAndCache(id, db)
-			out.push(await loadExternalMastodonAccount(actor))
+			out.push(await loadExternalMastodonAccount(db, actor))
 		} catch (err: any) {
 			console.warn(`failed to retrieve following (${id}): ${err.message}`)
 		}

--- a/functions/api/v1/accounts/[id]/statuses.ts
+++ b/functions/api/v1/accounts/[id]/statuses.ts
@@ -85,8 +85,6 @@ async function getRemoteStatuses(
 	const activities = await outbox.get(actor, limit)
 
 	// TODO: use account
-	// eslint-disable-next-line unused-imports/no-unused-vars
-	// const account = await loadExternalMastodonAccount(acct, actor)
 
 	const promises = activities.items.map(async (activity: Activity) => {
 		const actorId = objects.getApId(activity.actor)

--- a/functions/api/v1/accounts/[id]/statuses.ts
+++ b/functions/api/v1/accounts/[id]/statuses.ts
@@ -148,8 +148,12 @@ export async function getLocalStatuses(
 	const QUERY = `
 SELECT objects.*,
        actors.id as actor_id,
+       actors.type as actor_type,
+       actors.pubkey as actor_pubkey,
        actors.cdate as actor_cdate,
        actors.properties as actor_properties,
+       actors.is_admin as actor_is_admin,
+       actors.mastodon_id as actor_mastodon_id,
        outbox_objects.actor_id as publisher_actor_id,
        (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
        (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
@@ -193,7 +197,23 @@ LIMIT ?3 OFFSET ?4
 		afterCdate = row.cdate
 	}
 
-	const { success, error, results } = await db.prepare(QUERY).bind(actorId.toString(), afterCdate, limit, offset).all()
+	const { success, error, results } = await db.prepare(QUERY).bind(actorId.toString(), afterCdate, limit, offset).all<{
+		mastodon_id: string
+		id: string
+		cdate: string
+		properties: string
+		actor_id: string
+		actor_type: actors.Actor['type']
+		actor_pubkey: string | null
+		actor_cdate: string
+		actor_properties: string
+		actor_is_admin: 1 | null
+		actor_mastodon_id: string
+		publisher_actor_id: string
+		favourites_count: number
+		reblogs_count: number
+		replies_count: number
+	}>()
 	if (!success) {
 		throw new Error('SQL error: ' + error)
 	}

--- a/functions/api/v1/accounts/lookup.ts
+++ b/functions/api/v1/accounts/lookup.ts
@@ -1,0 +1,33 @@
+// https://docs.joinmastodon.org/methods/accounts/#lookup
+
+import { getAccount } from 'wildebeest/backend/src/accounts/getAccount'
+import { type Database, getDatabase } from 'wildebeest/backend/src/database'
+import { resourceNotFound } from 'wildebeest/backend/src/errors'
+import { ContextData } from 'wildebeest/backend/src/types/context'
+import { cors } from 'wildebeest/backend/src/utils/cors'
+import { Env } from 'wildebeest/consumer/src'
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+export const onRequest: PagesFunction<Env, '', ContextData> = async ({ request, env }) => {
+	return handleRequest(request, await getDatabase(env))
+}
+
+export async function handleRequest(req: Request, db: Database): Promise<Response> {
+	const url = new URL(req.url)
+
+	const acct = url.searchParams.get('acct')
+	if (acct === null || acct === '') {
+		return resourceNotFound('acct', '')
+	}
+
+	const account = await getAccount(url.hostname, db, acct)
+
+	if (account === null) {
+		return resourceNotFound('acct', acct)
+	}
+	return new Response(JSON.stringify(account), { headers })
+}

--- a/functions/api/v1/accounts/lookup.ts
+++ b/functions/api/v1/accounts/lookup.ts
@@ -12,20 +12,20 @@ const headers = {
 	'content-type': 'application/json; charset=utf-8',
 }
 
-export const onRequest: PagesFunction<Env, '', ContextData> = async ({ request, env }) => {
-	return handleRequest(request, await getDatabase(env))
-}
+type Dependency = { domain: string; db: Database }
 
-export async function handleRequest(req: Request, db: Database): Promise<Response> {
-	const url = new URL(req.url)
+export const onRequestGet: PagesFunction<Env, '', ContextData> = async ({ request, env }) => {
+	const url = new URL(request.url)
 
 	const acct = url.searchParams.get('acct')
 	if (acct === null || acct === '') {
 		return resourceNotFound('acct', '')
 	}
+	return handleRequest({ domain: url.hostname, db: await getDatabase(env) }, acct)
+}
 
-	const account = await getAccount(url.hostname, db, acct)
-
+export async function handleRequest({ domain, db }: Dependency, acct: string): Promise<Response> {
+	const account = await getAccount(domain, db, acct)
 	if (account === null) {
 		return resourceNotFound('acct', acct)
 	}

--- a/functions/api/v1/notifications/[id].ts
+++ b/functions/api/v1/notifications/[id].ts
@@ -44,7 +44,7 @@ export async function handleRequest(
 		throw new Error('unknown from actor')
 	}
 
-	const fromAccount = await loadExternalMastodonAccount(fromActor)
+	const fromAccount = await loadExternalMastodonAccount(db, fromActor)
 
 	const out: Notification = {
 		id: row.notif_id.toString(),

--- a/functions/api/v1/statuses/[id].ts
+++ b/functions/api/v1/statuses/[id].ts
@@ -80,7 +80,7 @@ export async function handleRequestDelete(
 	if (status === null) {
 		return errors.statusNotFound(id)
 	}
-	if (status.account.id !== actorToAcct(connectedActor)) {
+	if (status.account.acct !== actorToAcct(connectedActor)) {
 		return errors.statusNotFound(id)
 	}
 

--- a/functions/api/v1/statuses/[id].ts
+++ b/functions/api/v1/statuses/[id].ts
@@ -10,7 +10,7 @@ import { type Database, getDatabase } from 'wildebeest/backend/src/database'
 import * as errors from 'wildebeest/backend/src/errors'
 import { getMastodonStatusById, toMastodonStatusFromObject } from 'wildebeest/backend/src/mastodon/status'
 import * as timeline from 'wildebeest/backend/src/mastodon/timeline'
-import type { MastodonID } from 'wildebeest/backend/src/types'
+import type { MastodonId } from 'wildebeest/backend/src/types'
 import type { ContextData } from 'wildebeest/backend/src/types/context'
 import type { Env } from 'wildebeest/backend/src/types/env'
 import type { DeliverMessageBody, Queue } from 'wildebeest/backend/src/types/queue'
@@ -19,14 +19,14 @@ import { actorToAcct } from 'wildebeest/backend/src/utils/handle'
 
 export const onRequestGet: PagesFunction<Env, any, ContextData> = async ({ params, env, request, data }) => {
 	const domain = new URL(request.url).hostname
-	return handleRequestGet(await getDatabase(env), params.id as MastodonID, domain, data.connectedActor)
+	return handleRequestGet(await getDatabase(env), params.id as MastodonId, domain, data.connectedActor)
 }
 
 export const onRequestDelete: PagesFunction<Env, any, ContextData> = async ({ params, env, request, data }) => {
 	const domain = new URL(request.url).hostname
 	return handleRequestDelete(
 		await getDatabase(env),
-		params.id as MastodonID,
+		params.id as MastodonId,
 		data.connectedActor,
 		domain,
 		env.userKEK,
@@ -37,7 +37,7 @@ export const onRequestDelete: PagesFunction<Env, any, ContextData> = async ({ pa
 
 export async function handleRequestGet(
 	db: Database,
-	id: MastodonID,
+	id: MastodonId,
 	domain: string,
 	// To be used when we implement private statuses
 	// eslint-disable-next-line unused-imports/no-unused-vars
@@ -64,7 +64,7 @@ export async function handleRequestGet(
 
 export async function handleRequestDelete(
 	db: Database,
-	id: MastodonID,
+	id: MastodonId,
 	connectedActor: Person,
 	domain: string,
 	userKEK: string,

--- a/functions/api/v1/statuses/[id].ts
+++ b/functions/api/v1/statuses/[id].ts
@@ -10,7 +10,7 @@ import { type Database, getDatabase } from 'wildebeest/backend/src/database'
 import * as errors from 'wildebeest/backend/src/errors'
 import { getMastodonStatusById, toMastodonStatusFromObject } from 'wildebeest/backend/src/mastodon/status'
 import * as timeline from 'wildebeest/backend/src/mastodon/timeline'
-import type { UUID } from 'wildebeest/backend/src/types'
+import type { MastodonID } from 'wildebeest/backend/src/types'
 import type { ContextData } from 'wildebeest/backend/src/types/context'
 import type { Env } from 'wildebeest/backend/src/types/env'
 import type { DeliverMessageBody, Queue } from 'wildebeest/backend/src/types/queue'
@@ -19,14 +19,14 @@ import { actorToAcct } from 'wildebeest/backend/src/utils/handle'
 
 export const onRequestGet: PagesFunction<Env, any, ContextData> = async ({ params, env, request, data }) => {
 	const domain = new URL(request.url).hostname
-	return handleRequestGet(await getDatabase(env), params.id as UUID, domain, data.connectedActor)
+	return handleRequestGet(await getDatabase(env), params.id as MastodonID, domain, data.connectedActor)
 }
 
 export const onRequestDelete: PagesFunction<Env, any, ContextData> = async ({ params, env, request, data }) => {
 	const domain = new URL(request.url).hostname
 	return handleRequestDelete(
 		await getDatabase(env),
-		params.id as UUID,
+		params.id as MastodonID,
 		data.connectedActor,
 		domain,
 		env.userKEK,
@@ -37,7 +37,7 @@ export const onRequestDelete: PagesFunction<Env, any, ContextData> = async ({ pa
 
 export async function handleRequestGet(
 	db: Database,
-	id: UUID,
+	id: MastodonID,
 	domain: string,
 	// To be used when we implement private statuses
 	// eslint-disable-next-line unused-imports/no-unused-vars
@@ -64,7 +64,7 @@ export async function handleRequestGet(
 
 export async function handleRequestDelete(
 	db: Database,
-	id: UUID,
+	id: MastodonID,
 	connectedActor: Person,
 	domain: string,
 	userKEK: string,

--- a/functions/api/v1/statuses/[id].ts
+++ b/functions/api/v1/statuses/[id].ts
@@ -17,16 +17,27 @@ import type { DeliverMessageBody, Queue } from 'wildebeest/backend/src/types/que
 import { cors } from 'wildebeest/backend/src/utils/cors'
 import { actorToAcct } from 'wildebeest/backend/src/utils/handle'
 
-export const onRequestGet: PagesFunction<Env, any, ContextData> = async ({ params, env, request, data }) => {
+export const onRequestGet: PagesFunction<Env, 'id', ContextData> = async ({ params: { id }, env, request, data }) => {
+	if (typeof id !== 'string') {
+		return errors.statusNotFound(String(id))
+	}
 	const domain = new URL(request.url).hostname
-	return handleRequestGet(await getDatabase(env), params.id as MastodonId, domain, data.connectedActor)
+	return handleRequestGet(await getDatabase(env), id, domain, data.connectedActor)
 }
 
-export const onRequestDelete: PagesFunction<Env, any, ContextData> = async ({ params, env, request, data }) => {
+export const onRequestDelete: PagesFunction<Env, 'id', ContextData> = async ({
+	params: { id },
+	env,
+	request,
+	data,
+}) => {
+	if (typeof id !== 'string') {
+		return errors.statusNotFound(String(id))
+	}
 	const domain = new URL(request.url).hostname
 	return handleRequestDelete(
 		await getDatabase(env),
-		params.id as MastodonId,
+		id,
 		data.connectedActor,
 		domain,
 		env.userKEK,

--- a/functions/api/v2/media/[id].ts
+++ b/functions/api/v2/media/[id].ts
@@ -6,7 +6,7 @@ import { updateObjectProperty } from 'wildebeest/backend/src/activitypub/objects
 import type { Image } from 'wildebeest/backend/src/activitypub/objects/image'
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
 import * as errors from 'wildebeest/backend/src/errors'
-import type { UUID } from 'wildebeest/backend/src/types'
+import type { MastodonID } from 'wildebeest/backend/src/types'
 import type { ContextData } from 'wildebeest/backend/src/types/context'
 import type { Env } from 'wildebeest/backend/src/types/env'
 import type { MediaAttachment } from 'wildebeest/backend/src/types/media'
@@ -14,14 +14,14 @@ import { readBody } from 'wildebeest/backend/src/utils/body'
 import { cors } from 'wildebeest/backend/src/utils/cors'
 
 export const onRequestPut: PagesFunction<Env, any, ContextData> = async ({ params, env, request }) => {
-	return handleRequestPut(await getDatabase(env), params.id as UUID, request)
+	return handleRequestPut(await getDatabase(env), params.id as MastodonID, request)
 }
 
 type UpdateMedia = {
 	description?: string
 }
 
-export async function handleRequestPut(db: Database, id: UUID, request: Request): Promise<Response> {
+export async function handleRequestPut(db: Database, id: MastodonID, request: Request): Promise<Response> {
 	// Update the image properties
 	{
 		const image = (await getObjectByMastodonId(db, id)) as Image

--- a/functions/api/v2/media/[id].ts
+++ b/functions/api/v2/media/[id].ts
@@ -13,8 +13,11 @@ import type { MediaAttachment } from 'wildebeest/backend/src/types/media'
 import { readBody } from 'wildebeest/backend/src/utils/body'
 import { cors } from 'wildebeest/backend/src/utils/cors'
 
-export const onRequestPut: PagesFunction<Env, any, ContextData> = async ({ params, env, request }) => {
-	return handleRequestPut(await getDatabase(env), params.id as MastodonId, request)
+export const onRequestPut: PagesFunction<Env, 'id', ContextData> = async ({ params: { id }, env, request }) => {
+	if (typeof id !== 'string') {
+		return errors.mediaNotFound(String(id))
+	}
+	return handleRequestPut(await getDatabase(env), id, request)
 }
 
 type UpdateMedia = {

--- a/functions/api/v2/media/[id].ts
+++ b/functions/api/v2/media/[id].ts
@@ -6,7 +6,7 @@ import { updateObjectProperty } from 'wildebeest/backend/src/activitypub/objects
 import type { Image } from 'wildebeest/backend/src/activitypub/objects/image'
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
 import * as errors from 'wildebeest/backend/src/errors'
-import type { MastodonID } from 'wildebeest/backend/src/types'
+import type { MastodonId } from 'wildebeest/backend/src/types'
 import type { ContextData } from 'wildebeest/backend/src/types/context'
 import type { Env } from 'wildebeest/backend/src/types/env'
 import type { MediaAttachment } from 'wildebeest/backend/src/types/media'
@@ -14,14 +14,14 @@ import { readBody } from 'wildebeest/backend/src/utils/body'
 import { cors } from 'wildebeest/backend/src/utils/cors'
 
 export const onRequestPut: PagesFunction<Env, any, ContextData> = async ({ params, env, request }) => {
-	return handleRequestPut(await getDatabase(env), params.id as MastodonID, request)
+	return handleRequestPut(await getDatabase(env), params.id as MastodonId, request)
 }
 
 type UpdateMedia = {
 	description?: string
 }
 
-export async function handleRequestPut(db: Database, id: MastodonID, request: Request): Promise<Response> {
+export async function handleRequestPut(db: Database, id: MastodonId, request: Request): Promise<Response> {
 	// Update the image properties
 	{
 		const image = (await getObjectByMastodonId(db, id)) as Image

--- a/functions/api/v2/search.ts
+++ b/functions/api/v2/search.ts
@@ -50,7 +50,7 @@ export async function handleRequest(db: Database, request: Request): Promise<Res
 	if (useWebFinger && !isLocalHandle(query)) {
 		const res = await queryAcct(query, db)
 		if (res !== null) {
-			out.accounts.push(await loadExternalMastodonAccount(res, false, query))
+			out.accounts.push(await loadExternalMastodonAccount(db, res, query))
 		}
 	}
 
@@ -84,7 +84,7 @@ WHERE rowid IN (SELECT rowid FROM search_fts WHERE (preferredUsername MATCH ?1 O
 						mastodon_id: results[i].mastodon_id ?? (await setMastodonId(db, results[i].id, results[i].cdate)),
 					}
 					const actor = actorFromRow(row)
-					out.accounts.push(await loadExternalMastodonAccount(actor))
+					out.accounts.push(await loadExternalMastodonAccount(db, actor))
 				}
 			}
 		} catch (err: any) {

--- a/migrations/0012_add_mastodon_id.sql
+++ b/migrations/0012_add_mastodon_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE actors ADD mastodon_id TEXT;

--- a/migrations/0013_add_id_sequences.sql
+++ b/migrations/0013_add_id_sequences.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS id_sequences (
+    key TEXT PRIMARY KEY,
+    value INTEGER NOT NULL DEFAULT 0
+);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"pages": "NO_D1_WARNING=true wrangler pages",
 		"database:migrate": "npm run d1 -- migrations apply DATABASE",
 		"database:create-mock": "rm -f .wrangler/state/d1/DATABASE.sqlite3 && CI=true npm run database:migrate -- --local && node ./frontend/mock-db/run.mjs",
-		"dev": "export COMMIT_HASH=$(git rev-parse HEAD) && npm run build && npm run database:migrate -- --local && npm run pages -- dev frontend/dist --d1 DATABASE --persist --compatibility-date=2022-12-20 --binding 'INSTANCE_TITLE=Test Wildebeest' 'INSTANCE_DESCR=My Wildebeest Instance' 'ACCESS_AUTH_DOMAIN=0.0.0.0.cloudflareaccess.com' 'ACCESS_AUD=DEV_AUD' 'ADMIN_EMAIL=george@test.email' --live-reload",
+		"dev": "export COMMIT_HASH=$(git rev-parse HEAD) && npm run build && npm run database:migrate -- --local && npm run pages -- dev frontend/dist --d1 DATABASE --persist --compatibility-date=2022-12-20 --live-reload",
 		"ci-dev-test-ui": "npm run build && npm run database:create-mock && npm run pages -- dev frontend/dist --d1 DATABASE --persist --port 8788  --binding 'INSTANCE_TITLE=Test Wildebeest' 'INSTANCE_DESCR=My Wildebeest Instance' 'ACCESS_AUTH_DOMAIN=0.0.0.0.cloudflareaccess.com' 'ACCESS_AUD=DEV_AUD' 'ADMIN_EMAIL=george@test.email' --compatibility-date=2022-12-20",
 		"deploy:init": "npm run pages -- project create wildebeest && npm run d1 -- create wildebeest",
 		"deploy": "npm run build && npm run database:migrate && npm run pages -- publish frontend/dist --project-name=wildebeest"


### PR DESCRIPTION
* Changed Mastodon ID generation method from UUID to a modified version of Snowflake used by Mastodon
* Changed MastodonAccount to use actual values where values were stubbed
* Implemented `api/v1/accounts/lookup` and modified `api/v1/accounts/:id`
* Static typing has been improved to reduce the use of `any` in some cases