### PR TITLE
Support requests with only `since_id` parameter

### DIFF
--- a/functions/api/v1/accounts/[id]/statuses.ts
+++ b/functions/api/v1/accounts/[id]/statuses.ts
@@ -123,12 +123,15 @@ WHERE objects.mastodon_id = ?1
 			}
 			since = results[0].cdate
 		}
-	} else if (params.minId) {
-		const { results } = await db.prepare(CDATE_QUERY).bind(params.minId).all<{ cdate: string }>()
-		if (results === undefined || results.length === 0) {
-			return resourceNotFound('min_id', params.minId)
+	} else {
+		const minId = params.minId || params.sinceId
+		if (minId) {
+			const { results } = await db.prepare(CDATE_QUERY).bind(minId).all<{ cdate: string }>()
+			if (results === undefined || results.length === 0) {
+				return resourceNotFound('min_id', minId)
+			}
+			cdate = results[0].cdate
 		}
-		cdate = results[0].cdate
 	}
 
 	const { success, error, results } = await db


### PR DESCRIPTION
I found that my mobile Mastodon client was making requests using only `since_id` parameter when retrieving new posts, so I fixed it to support that.

I thought `since_id` was only used in combination with `max_id`, but I was wrong!