### PR TITLE
Change to set UserAgent as needed

### DIFF
--- a/backend/src/activitypub/actors/index.ts
+++ b/backend/src/activitypub/actors/index.ts
@@ -15,6 +15,7 @@ import { Handle, handleToMastodonUrl, handleToPleromaUrl, RemoteHandle } from 'w
 import { generateMastodonId } from 'wildebeest/backend/src/utils/id'
 import { generateUserKey } from 'wildebeest/backend/src/utils/key-ops'
 import { defaultImages } from 'wildebeest/config/accounts'
+import { UA } from 'wildebeest/config/ua'
 
 const isTesting = typeof jest !== 'undefined'
 
@@ -57,6 +58,7 @@ export interface Person extends Actor {
 export async function fetchActor(url: string | URL): Promise<Remote<Actor>> {
 	const headers = {
 		accept: 'application/activity+json',
+		'User-Agent': UA,
 	}
 	const res = await fetch(url, { headers })
 	if (!res.ok) {

--- a/backend/src/activitypub/objects/collection.ts
+++ b/backend/src/activitypub/objects/collection.ts
@@ -1,4 +1,5 @@
 import type { ApObject } from 'wildebeest/backend/src/activitypub/objects'
+import { UA } from 'wildebeest/config/ua'
 
 export interface Collection<T> extends ApObject {
 	totalItems: number
@@ -17,6 +18,7 @@ export interface OrderedCollectionPage<T> extends ApObject {
 
 const headers = {
 	accept: 'application/activity+json',
+	'User-Agent': UA,
 }
 
 export async function getMetadata<T>(url: URL): Promise<OrderedCollection<T>> {

--- a/backend/src/activitypub/objects/index.ts
+++ b/backend/src/activitypub/objects/index.ts
@@ -4,6 +4,7 @@ import type { MastodonId } from 'wildebeest/backend/src/types'
 import { isUUID } from 'wildebeest/backend/src/utils'
 import { generateMastodonId } from 'wildebeest/backend/src/utils/id'
 import { Intersect, RequiredProps, SingleOrArray } from 'wildebeest/backend/src/utils/type'
+import { UA } from 'wildebeest/config/ua'
 
 export const originalActorIdSymbol = Symbol()
 export const originalObjectIdSymbol = Symbol()
@@ -152,6 +153,7 @@ export async function createObject<T extends ApObject>(
 export async function get<T>(url: URL): Promise<T> {
 	const headers = {
 		accept: 'application/activity+json',
+		'User-Agent': UA,
 	}
 	const res = await fetch(url, { headers })
 	if (!res.ok) {

--- a/backend/src/utils/httpsigjs/verifier.ts
+++ b/backend/src/utils/httpsigjs/verifier.ts
@@ -1,3 +1,5 @@
+import { UA } from 'wildebeest/config/ua'
+
 import { importPublicKey, str2ab } from '../key-ops'
 import { ParsedSignature } from './parser'
 
@@ -21,7 +23,10 @@ export async function verifySignature(parsedSignature: ParsedSignature, key: Cry
 export async function fetchKey(parsedSignature: ParsedSignature): Promise<CryptoKey | null> {
 	const url = parsedSignature.keyId
 	const res = await fetch(url, {
-		headers: { Accept: 'application/activity+json' },
+		headers: {
+			Accept: 'application/activity+json',
+			'User-Agent': UA,
+		},
 	})
 	if (!res.ok) {
 		console.warn(`failed to fetch keys from "${url}", returned ${res.status}.`)

--- a/backend/src/utils/httpsigjs/verifier.ts
+++ b/backend/src/utils/httpsigjs/verifier.ts
@@ -29,7 +29,9 @@ export async function fetchKey(parsedSignature: ParsedSignature): Promise<Crypto
 		},
 	})
 	if (!res.ok) {
-		console.warn(`failed to fetch keys from "${url}", returned ${res.status}.`)
+		if (res.status !== 410) {
+			console.warn(`failed to fetch keys from "${url}", returned ${res.status}.`)
+		}
 		return null
 	}
 

--- a/config/ua.ts
+++ b/config/ua.ts
@@ -1,5 +1,7 @@
-import { WILDEBEEST_VERSION, MASTODON_API_VERSION } from 'wildebeest/config/versions'
+import { MASTODON_API_VERSION, WILDEBEEST_VERSION } from 'wildebeest/config/versions'
 
 export function getFederationUA(domain: string): string {
 	return `Wildebeest/${WILDEBEEST_VERSION} (Mastodon/${MASTODON_API_VERSION}; +${domain})`
 }
+
+export const UA = `Wildebeest/${WILDEBEEST_VERSION} (Mastodon/${MASTODON_API_VERSION})`


### PR DESCRIPTION
Some instances look at the User-Agent request header and deny access. So set a User-Agent that I think is appropriate for them. (`Wildebeest/x.x.x (Mastodon/x.x.x)`)