### PR TITLE
[Breaking Changes] Improve handling of reblog and post visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 /test-results/
 /playwright-report/
 /playwright/.cache/
+/coverage/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
 	"cSpell.words": [
 		"activitypub",
 		"cdate",
+		"favourite",
 		"favourited",
 		"favourites",
 		"idempotency",
@@ -9,7 +10,9 @@
 		"reblog",
 		"reblogged",
 		"reblogger",
-		"reblogs"
+		"reblogs",
+		"webfinger",
+		"webpush"
 	],
 	"typescript.preferences.importModuleSpecifier": "non-relative",
 	"editor.codeActionsOnSave": ["source.addMissingImports", "source.fixAll.eslint"]

--- a/backend/src/accounts/alias.ts
+++ b/backend/src/accounts/alias.ts
@@ -25,7 +25,7 @@ export async function addAlias(db: Database, alias: string, connectedActor: Acto
 	// For Mastodon to deliver the Move Activity we need to be following the
 	// "moving from" actor.
 	{
-		const activity = createFollowActivity(domain, connectedActor, actor)
+		const activity = await createFollowActivity(db, domain, connectedActor, actor)
 		const signingKey = await getSigningKey(userKEK, db, connectedActor)
 		await deliverToActor(signingKey, connectedActor, actor, activity, domain)
 	}

--- a/backend/src/activitypub/activities/accept.ts
+++ b/backend/src/activitypub/activities/accept.ts
@@ -1,8 +1,8 @@
 import { isLocalAccount } from 'wildebeest/backend/src/accounts/getAccount'
 import {
 	AcceptActivity,
-	createActivityId,
 	getActivityObject,
+	insertActivity,
 	isFollowActivity,
 } from 'wildebeest/backend/src/activitypub/activities'
 import { Actor, getActorById, getAndCache } from 'wildebeest/backend/src/activitypub/actors'
@@ -11,14 +11,18 @@ import { Database } from 'wildebeest/backend/src/database'
 import { acceptFollowing } from 'wildebeest/backend/src/mastodon/follow'
 import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 
-export function createAcceptActivity(domain: string, actor: Actor, object: ApObject): AcceptActivity {
-	return {
+export async function createAcceptActivity(
+	db: Database,
+	domain: string,
+	actor: Actor,
+	object: ApObject
+): Promise<AcceptActivity> {
+	return await insertActivity(db, domain, actor, {
 		'@context': 'https://www.w3.org/ns/activitystreams',
 		type: 'Accept',
-		id: createActivityId(domain),
 		actor: actor.id,
 		object,
-	}
+	})
 }
 
 // https://www.w3.org/TR/activitystreams-vocabulary/#dfn-accept

--- a/backend/src/activitypub/activities/delete.ts
+++ b/backend/src/activitypub/activities/delete.ts
@@ -1,4 +1,4 @@
-import { createActivityId, DeleteActivity } from 'wildebeest/backend/src/activitypub/activities'
+import { DeleteActivity, insertActivity } from 'wildebeest/backend/src/activitypub/activities'
 import { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import {
 	ApObject,
@@ -9,14 +9,18 @@ import {
 } from 'wildebeest/backend/src/activitypub/objects'
 import { Database } from 'wildebeest/backend/src/database'
 
-export function createDeleteActivity(domain: string, actor: Actor, object: ApObject): DeleteActivity {
-	return {
-		'@context': ['https://www.w3.org/ns/activitystreams'],
-		id: createActivityId(domain),
+export async function createDeleteActivity(
+	db: Database,
+	domain: string,
+	actor: Actor,
+	object: ApObject
+): Promise<DeleteActivity> {
+	return await insertActivity(db, domain, actor, {
+		'@context': 'https://www.w3.org/ns/activitystreams',
 		type: 'Delete',
 		actor: actor.id,
 		object,
-	}
+	})
 }
 
 // https://www.w3.org/TR/activitystreams-vocabulary/#dfn-delete

--- a/backend/src/activitypub/activities/like.ts
+++ b/backend/src/activitypub/activities/like.ts
@@ -1,6 +1,6 @@
 // https://www.w3.org/TR/activitystreams-vocabulary/#dfn-like
 
-import { createActivityId, LikeActivity } from 'wildebeest/backend/src/activitypub/activities'
+import { insertActivity, LikeActivity } from 'wildebeest/backend/src/activitypub/activities'
 import { Actor, getActorById, getAndCache } from 'wildebeest/backend/src/activitypub/actors'
 import { getApId, getObjectById, originalActorIdSymbol } from 'wildebeest/backend/src/activitypub/objects'
 import { Database } from 'wildebeest/backend/src/database'
@@ -8,14 +8,18 @@ import { insertLike } from 'wildebeest/backend/src/mastodon/like'
 import { createNotification, sendLikeNotification } from 'wildebeest/backend/src/mastodon/notification'
 import { JWK } from 'wildebeest/backend/src/webpush/jwk'
 
-export function createLikeActivity(domain: string, actor: Actor, object: URL): LikeActivity {
-	return {
+export async function createLikeActivity(
+	db: Database,
+	domain: string,
+	actor: Actor,
+	object: URL
+): Promise<LikeActivity> {
+	return await insertActivity(db, domain, actor, {
 		'@context': 'https://www.w3.org/ns/activitystreams',
-		id: createActivityId(domain),
 		type: 'Like',
 		actor: actor.id,
 		object,
-	}
+	})
 }
 
 // https://www.w3.org/TR/activitystreams-vocabulary/#dfn-like

--- a/backend/src/activitypub/activities/undo.ts
+++ b/backend/src/activitypub/activities/undo.ts
@@ -1,14 +1,19 @@
-import { createActivityId, UndoActivity } from 'wildebeest/backend/src/activitypub/activities'
+import { insertActivity, UndoActivity } from 'wildebeest/backend/src/activitypub/activities'
 import { createFollowActivity } from 'wildebeest/backend/src/activitypub/activities/follow'
 import { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import { ApObject } from 'wildebeest/backend/src/activitypub/objects'
+import { Database } from 'wildebeest/backend/src/database'
 
-export function createUnfollowActivity(domain: string, actor: Actor, object: ApObject): UndoActivity {
-	return {
+export async function createUnfollowActivity(
+	db: Database,
+	domain: string,
+	actor: Actor,
+	object: ApObject
+): Promise<UndoActivity> {
+	return await insertActivity(db, domain, actor, {
 		'@context': 'https://www.w3.org/ns/activitystreams',
-		id: createActivityId(domain),
 		type: 'Undo',
 		actor: actor.id,
-		object: createFollowActivity(domain, actor, object),
-	}
+		object: await createFollowActivity(db, domain, actor, object),
+	})
 }

--- a/backend/src/activitypub/activities/update.ts
+++ b/backend/src/activitypub/activities/update.ts
@@ -1,4 +1,4 @@
-import { createActivityId, getActivityObject, UpdateActivity } from 'wildebeest/backend/src/activitypub/activities'
+import { getActivityObject, insertActivity, UpdateActivity } from 'wildebeest/backend/src/activitypub/activities'
 import { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import {
 	ApObject,
@@ -10,14 +10,18 @@ import {
 } from 'wildebeest/backend/src/activitypub/objects'
 import { Database } from 'wildebeest/backend/src/database'
 
-export function createUpdateActivity(domain: string, actor: Actor, object: ApObject): UpdateActivity {
-	return {
-		'@context': ['https://www.w3.org/ns/activitystreams'],
-		id: createActivityId(domain),
+export async function createUpdateActivity(
+	db: Database,
+	domain: string,
+	actor: Actor,
+	object: ApObject
+): Promise<UpdateActivity> {
+	return await insertActivity(db, domain, actor, {
+		'@context': 'https://www.w3.org/ns/activitystreams',
 		type: 'Update',
 		actor: actor.id,
 		object,
-	}
+	})
 }
 
 export async function handleUpdateActivity(activity: UpdateActivity, db: Database) {

--- a/backend/src/activitypub/actors/outbox.ts
+++ b/backend/src/activitypub/actors/outbox.ts
@@ -1,35 +1,47 @@
 import type { Activity } from 'wildebeest/backend/src/activitypub/activities'
-import { PUBLIC_GROUP } from 'wildebeest/backend/src/activitypub/activities'
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
-import type { ApObject } from 'wildebeest/backend/src/activitypub/objects'
+import { type ApObject, ApObjectOrId } from 'wildebeest/backend/src/activitypub/objects'
 import type { OrderedCollection } from 'wildebeest/backend/src/activitypub/objects/collection'
 import { getMetadata, loadItems } from 'wildebeest/backend/src/activitypub/objects/collection'
 import { type Database } from 'wildebeest/backend/src/database'
+import { unique } from 'wildebeest/backend/src/utils'
 
 export async function addObjectInOutbox<T extends ApObject>(
 	db: Database,
 	actor: Actor,
 	obj: T,
-	published_date?: string,
-	target: string = PUBLIC_GROUP
-) {
+	objTo: T['to'] = obj.to ?? [],
+	objCc: T['cc'] = obj.cc ?? [],
+	published_date?: string
+): Promise<string> {
 	const id = crypto.randomUUID()
+
+	const to: ApObjectOrId[] = Array.isArray(objTo) ? objTo : [objTo]
+	const cc: ApObjectOrId[] = Array.isArray(objCc) ? objCc : [objCc]
 
 	let out
 	if (published_date !== undefined) {
 		out = await db
-			.prepare('INSERT INTO outbox_objects(id, actor_id, object_id, published_date, target) VALUES(?, ?, ?, ?, ?)')
-			.bind(id, actor.id.toString(), obj.id.toString(), published_date, target)
+			.prepare('INSERT INTO outbox_objects(id, actor_id, object_id, published_date, `to`, cc) VALUES(?, ?, ?, ?, ?, ?)')
+			.bind(
+				id,
+				actor.id.toString(),
+				obj.id.toString(),
+				published_date,
+				JSON.stringify(unique(to)),
+				JSON.stringify(unique(cc))
+			)
 			.run()
 	} else {
 		out = await db
-			.prepare('INSERT INTO outbox_objects(id, actor_id, object_id, target) VALUES(?, ?, ?, ?)')
-			.bind(id, actor.id.toString(), obj.id.toString(), target)
+			.prepare('INSERT INTO outbox_objects(id, actor_id, object_id, `to`, cc) VALUES(?, ?, ?, ?, ?)')
+			.bind(id, actor.id.toString(), obj.id.toString(), JSON.stringify(unique(to)), JSON.stringify(unique(cc)))
 			.run()
 	}
 	if (!out.success) {
 		throw new Error('SQL error: ' + out.error)
 	}
+	return id
 }
 
 export async function get<T extends Activity>(actor: Actor, limit?: number): Promise<OrderedCollection<T>> {

--- a/backend/src/activitypub/objects/note.ts
+++ b/backend/src/activitypub/objects/note.ts
@@ -19,7 +19,7 @@ export type Note = RequiredProps<objects.ApObject, 'cc' | 'to'> & {
 		content: string
 		mediaType: string
 	}
-	attributedTo?: objects.ApObjectId
+	attributedTo: objects.ApObjectId
 	attachment: Array<objects.ApObject>
 	tag?: Array<Link>
 	spoiler_text?: string
@@ -49,7 +49,7 @@ export async function createPublicNote(
 ) {
 	const cc =
 		ccActors.size > 0
-			? [actor.followers.toString(), ...Array.from(ccActors).map((a) => a.id.toString())]
+			? [actor.followers.toString(), ...[...ccActors].map((a) => a.id.toString())]
 			: [actor.followers.toString()]
 
 	return await createNote(domain, db, content, actor, [PUBLIC_GROUP], cc, attachment, extraProperties)
@@ -92,9 +92,20 @@ export async function createDirectNote(
 	attachment: objects.ApObject[] = [],
 	extraProperties: ExtraProperties
 ) {
-	const to = toActors.size > 0 ? Array.from(toActors).map((a) => a.id.toString()) : []
+	if (toActors.size === 0) {
+		throw new Error('toActors must not be empty')
+	}
 
-	return await createNote(domain, db, content, actor, to, [], attachment, extraProperties)
+	return await createNote(
+		domain,
+		db,
+		content,
+		actor,
+		Array.from(toActors).map((a) => a.id.toString()),
+		[],
+		attachment,
+		extraProperties
+	)
 }
 
 async function createNote(

--- a/backend/src/database/d1.ts
+++ b/backend/src/database/d1.ts
@@ -10,6 +10,10 @@ const qb: QueryBuilder = {
 		return `${qb.jsonExtract(obj, prop)} IS NULL`
 	},
 
+	jsonArrayLength(array: string): string {
+		return `json_array_length(${array})`
+	},
+
 	set(array: string): string {
 		return `(SELECT value FROM json_each(${array}))`
 	},

--- a/backend/src/database/index.ts
+++ b/backend/src/database/index.ts
@@ -31,6 +31,7 @@ export interface PreparedStatement {
 export interface QueryBuilder {
 	jsonExtract(obj: string, prop: string): string
 	jsonExtractIsNull(obj: string, prop: string): string
+	jsonArrayLength(array: string): string
 	set(array: string): string
 	epoch(): string
 	insertOrIgnore(q: string): string

--- a/backend/src/database/neon.ts
+++ b/backend/src/database/neon.ts
@@ -19,6 +19,10 @@ const qb: QueryBuilder = {
 		return `${qb.jsonExtract(obj, prop)} = 'null'`
 	},
 
+	jsonArrayLength(array: string): string {
+		return `jsonb_array_length(${array})})`
+	},
+
 	set(array: string): string {
 		return `(SELECT value::text FROM json_array_elements_text(${array}))`
 	},
@@ -77,9 +81,8 @@ export default async function make(env: Pick<Env, 'NEON_DATABASE_URL'>): Promise
 			return results
 		},
 
-		async exec<T = unknown>(query: string): Promise<Result<T>> {
+		async exec<T = unknown>(): Promise<Result<T>> {
 			throw new Error('not implemented')
-			console.log(query)
 		},
 	}
 }

--- a/backend/src/errors/index.ts
+++ b/backend/src/errors/index.ts
@@ -66,6 +66,10 @@ export function resourceNotFound(name: string, id: string) {
 	return makeErrorResponse('Resource not found', 404, `${name} "${id}" not found`)
 }
 
+export function recordNotFound(detail?: string) {
+	return makeErrorResponse('Record not found', 404, detail)
+}
+
 export function validationError(detail: string) {
 	return makeErrorResponse('Validation failed', 422, detail)
 }

--- a/backend/src/mastodon/follow.ts
+++ b/backend/src/mastodon/follow.ts
@@ -181,3 +181,14 @@ export async function isNotFollowing(db: Database, actor: Actor, target: Actor):
 
 	return following === 0
 }
+
+export async function isFollowing(db: Database, actor: Actor, target: Actor): Promise<boolean> {
+	const { following } = await db
+		.prepare(
+			'SELECT COUNT(*) > 0 as following FROM actor_following WHERE actor_id = ?1 AND target_actor_id = ?2 AND state = ?3'
+		)
+		.bind(actor.id.toString(), target.id.toString(), STATE_ACCEPTED)
+		.first<{ following: 1 | 0 }>()
+
+	return following === 1
+}

--- a/backend/src/mastodon/reblog.ts
+++ b/backend/src/mastodon/reblog.ts
@@ -1,8 +1,13 @@
 // Also known as boost.
 
+import { AnnounceActivity, PUBLIC_GROUP } from 'wildebeest/backend/src/activitypub/activities'
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
-import type { ApObject } from 'wildebeest/backend/src/activitypub/objects'
+import { getApId } from 'wildebeest/backend/src/activitypub/objects'
+import { Note } from 'wildebeest/backend/src/activitypub/objects/note'
 import { type Database } from 'wildebeest/backend/src/database'
+import { MastodonId } from 'wildebeest/backend/src/types'
+import { isUUID } from 'wildebeest/backend/src/utils'
+import { generateMastodonId } from 'wildebeest/backend/src/utils/id'
 
 import { addObjectInOutbox } from '../activitypub/actors/outbox'
 import { getResultsField } from './utils'
@@ -14,25 +19,46 @@ import { getResultsField } from './utils'
  * @param actor Reblogger
  * @param obj ActivityPub object to reblog
  */
-export async function createReblog(db: Database, actor: Actor, obj: ApObject) {
-	await Promise.all([addObjectInOutbox(db, actor, obj), insertReblog(db, actor, obj)])
+export async function createReblog(
+	db: Database,
+	actor: Actor,
+	obj: Note,
+	activity: Pick<AnnounceActivity, 'id' | 'to' | 'cc'>,
+	published?: string
+) {
+	const outboxObjectId = await addObjectInOutbox(
+		db,
+		actor,
+		obj,
+		activity.to ?? obj.to,
+		activity.cc ?? obj.cc,
+		published
+	)
+	await insertReblog(db, actor, obj, activity.id.toString(), outboxObjectId)
 }
 
-export async function insertReblog(db: Database, actor: Actor, obj: ApObject) {
-	const id = crypto.randomUUID()
-
+async function insertReblog(db: Database, actor: Actor, obj: Note, activityId: string, outboxObjectId: string) {
 	const query = `
-		INSERT INTO actor_reblogs (id, actor_id, object_id)
-		VALUES (?, ?, ?)
+		INSERT INTO actor_reblogs (id, actor_id, object_id, outbox_object_id, mastodon_id)
+		VALUES (?, ?, ?, ?, ?)
 	`
 
-	const out = await db.prepare(query).bind(id, actor.id.toString(), obj.id.toString()).run()
+	const out = await db
+		.prepare(query)
+		.bind(
+			activityId,
+			actor.id.toString(),
+			obj.id.toString(),
+			outboxObjectId,
+			await generateMastodonId(db, 'actor_reblogs', new Date())
+		)
+		.run()
 	if (!out.success) {
 		throw new Error('SQL error: ' + out.error)
 	}
 }
 
-export function getReblogs(db: Database, obj: ApObject): Promise<Array<string>> {
+export function getReblogs(db: Database, obj: Note): Promise<Array<string>> {
 	const query = `
 		SELECT actor_id FROM actor_reblogs WHERE object_id=?
 	`
@@ -42,11 +68,59 @@ export function getReblogs(db: Database, obj: ApObject): Promise<Array<string>> 
 	return getResultsField(statement, 'actor_id')
 }
 
-export async function hasReblog(db: Database, actor: Actor, obj: ApObject): Promise<boolean> {
+export async function hasReblog(db: Database, actor: Actor, obj: Note): Promise<boolean> {
 	const query = `
 		SELECT count(*) as count FROM actor_reblogs WHERE object_id=?1 AND actor_id=?2
 	`
 
 	const { count } = await db.prepare(query).bind(obj.id.toString(), actor.id.toString()).first<{ count: number }>()
 	return count > 0
+}
+
+export function reblogNotAllowed(actor: Actor, note: Note, activity: AnnounceActivity): boolean {
+	const noteTo = (Array.isArray(note.to) ? note.to : [note.to]).map((to) => getApId(to).toString())
+	const noteCc = (Array.isArray(note.cc) ? note.cc : [note.cc]).map((cc) => getApId(cc).toString())
+
+	if (actor.id.toString() !== note.attributedTo.toString()) {
+		// reblogging others' posts is limited only to public or unlisted ones
+		return !(noteTo.includes(PUBLIC_GROUP) || noteCc.includes(PUBLIC_GROUP))
+	}
+
+	// self reblog
+
+	// public or unlisted status -> allowed all visibility
+	if (noteTo.includes(PUBLIC_GROUP) || noteCc.includes(PUBLIC_GROUP)) {
+		return false
+	}
+
+	const activityTo =
+		activity.to === undefined
+			? []
+			: (Array.isArray(activity.to) ? activity.to : [activity.to]).map((to) => getApId(to).toString())
+	const activityCc =
+		activity.cc === undefined
+			? []
+			: (Array.isArray(activity.cc) ? activity.cc : [activity.cc]).map((cc) => getApId(cc).toString())
+
+	// private status -> allowed only private or direct visibility
+	if (noteTo.includes(actor.followers.toString())) {
+		return activityTo.includes(PUBLIC_GROUP) || activityCc.includes(PUBLIC_GROUP)
+	}
+	// direct status -> allowed only direct visibility (exact match)
+	return !(activityTo.every((to) => noteTo.includes(to)) && activityCc.every((cc) => noteCc.includes(cc)))
+}
+
+export async function ensureReblogMastodonId(db: Database, mastodonId: MastodonId, cdate: string): Promise<MastodonId> {
+	if (!isUUID(mastodonId)) {
+		return mastodonId
+	}
+	const newMastodonId = await generateMastodonId(db, 'actor_reblogs', new Date(cdate))
+	const { success, error } = await db
+		.prepare(`UPDATE actor_reblogs SET mastodon_id=?1 WHERE mastodon_id=?2`)
+		.bind(newMastodonId, mastodonId)
+		.run()
+	if (!success) {
+		throw new Error('SQL error: ' + error)
+	}
+	return newMastodonId
 }

--- a/backend/src/mastodon/reply.ts
+++ b/backend/src/mastodon/reply.ts
@@ -1,5 +1,6 @@
+import { PUBLIC_GROUP } from 'wildebeest/backend/src/activitypub/activities'
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors'
-import { type ApObject, ensureObjectMastodonId } from 'wildebeest/backend/src/activitypub/objects'
+import { type ApObject } from 'wildebeest/backend/src/activitypub/objects'
 import { type Database } from 'wildebeest/backend/src/database'
 import { toMastodonStatusFromRow } from 'wildebeest/backend/src/mastodon/status'
 import type { MastodonStatus } from 'wildebeest/backend/src/types/status'
@@ -21,44 +22,69 @@ export async function insertReply(db: Database, actor: Actor, obj: ApObject, inR
 
 export async function getReplies(domain: string, db: Database, obj: ApObject): Promise<Array<MastodonStatus>> {
 	const QUERY = `
-SELECT objects.*,
-       actors.id as actor_id,
-       actors.type as actor_type,
-       actors.pubkey as actor_pubkey,
-       actors.cdate as actor_cdate,
-       actors.properties as actor_properties,
-       actors.is_admin as actor_is_admin,
-       actors.mastodon_id as actor_mastodon_id,
-       actor_replies.actor_id as publisher_actor_id,
-       (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
-       (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
-       (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count
-FROM actor_replies
-INNER JOIN objects ON objects.id=actor_replies.object_id
-INNER JOIN actors ON actors.id=actor_replies.actor_id
-WHERE actor_replies.in_reply_to_object_id=?
-ORDER by actor_replies.cdate DESC
-LIMIT ?
+SELECT
+  objects.id,
+  objects.mastodon_id,
+  objects.cdate,
+  objects.properties,
+
+  actors.id as actor_id,
+  actors.type as actor_type,
+  actors.pubkey as actor_pubkey,
+  actors.cdate as actor_cdate,
+  actors.properties as actor_properties,
+  actors.is_admin as actor_is_admin,
+  actors.mastodon_id as actor_mastodon_id,
+
+  outbox_objects.actor_id as publisher_actor_id,
+  outbox_objects.published_date as publisher_published,
+  outbox_objects.'to' as publisher_to,
+  outbox_objects.cc as publisher_cc,
+
+  (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
+  (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
+  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count
+FROM outbox_objects
+  INNER JOIN actor_replies ON actor_replies.object_id = outbox_objects.object_id
+  INNER JOIN objects ON objects.id = actor_replies.object_id
+  INNER JOIN actors ON actors.id = actor_replies.actor_id
+WHERE
+  objects.type = 'Note'
+  AND actor_replies.in_reply_to_object_id = ?1
+  AND (EXISTS(SELECT 1 FROM json_each(outbox_objects.'to') WHERE json_each.value IN ${db.qb.set('?3')})
+        OR EXISTS(SELECT 1 FROM json_each(outbox_objects.cc) WHERE json_each.value IN ${db.qb.set('?3')}))
+ORDER BY ${db.qb.timeNormalize('outbox_objects.published_date')} DESC
+LIMIT ?2
 `
 	const DEFAULT_LIMIT = 20
 
-	const { success, error, results } = await db.prepare(QUERY).bind(obj.id.toString(), DEFAULT_LIMIT).all<{
-		mastodon_id: string
-		id: string
-		cdate: string
-		properties: string
-		actor_id: string
-		actor_type: Actor['type']
-		actor_pubkey: string | null
-		actor_cdate: string
-		actor_properties: string
-		actor_is_admin: 1 | null
-		actor_mastodon_id: string
-		publisher_actor_id: string
-		favourites_count: number
-		reblogs_count: number
-		replies_count: number
-	}>()
+	// TODO: use connectedActor for ?3
+	const { success, error, results } = await db
+		.prepare(QUERY)
+		.bind(obj.id.toString(), DEFAULT_LIMIT, JSON.stringify([PUBLIC_GROUP]))
+		.all<{
+			id: string
+			mastodon_id: string
+			cdate: string
+			properties: string
+
+			actor_id: string
+			actor_type: Actor['type']
+			actor_pubkey: string | null
+			actor_cdate: string
+			actor_properties: string
+			actor_is_admin: 1 | null
+			actor_mastodon_id: string
+
+			publisher_actor_id: string
+			publisher_published: string
+			publisher_to: string
+			publisher_cc: string
+
+			favourites_count: number
+			reblogs_count: number
+			replies_count: number
+		}>()
 	if (!success) {
 		throw new Error('SQL error: ' + error)
 	}
@@ -68,11 +94,8 @@ LIMIT ?
 
 	const out: Array<MastodonStatus> = []
 
-	for (let i = 0, len = results.length; i < len; i++) {
-		const result = results[i]
-		result.mastodon_id = await ensureObjectMastodonId(db, result.mastodon_id, result.cdate)
-
-		const status = await toMastodonStatusFromRow(domain, db, result)
+	for (const result of results) {
+		const status = await toMastodonStatusFromRow(domain, db, { ...result, reblog_id: null })
 		if (status !== null) {
 			out.push(status)
 		}

--- a/backend/src/mastodon/timeline.ts
+++ b/backend/src/mastodon/timeline.ts
@@ -1,9 +1,9 @@
 import { PUBLIC_GROUP } from 'wildebeest/backend/src/activitypub/activities'
 import type { Actor } from 'wildebeest/backend/src/activitypub/actors/'
-import { ensureObjectMastodonId } from 'wildebeest/backend/src/activitypub/objects'
 import type { Cache } from 'wildebeest/backend/src/cache'
 import { type Database } from 'wildebeest/backend/src/database'
 import { toMastodonStatusFromRow } from 'wildebeest/backend/src/mastodon/status'
+import { MastodonId } from 'wildebeest/backend/src/types'
 import type { MastodonStatus } from 'wildebeest/backend/src/types/status'
 
 export async function pregenerateTimelines(domain: string, db: Database, cache: Cache, actor: Actor) {
@@ -12,103 +12,139 @@ export async function pregenerateTimelines(domain: string, db: Database, cache: 
 }
 
 export async function getHomeTimeline(domain: string, db: Database, actor: Actor): Promise<Array<MastodonStatus>> {
-	const { results: following } = await db
+	const { results: q1Results } = await db
 		.prepare(
 			`
-            SELECT
-                actor_following.target_actor_id as id,
-                ${db.qb.jsonExtract('actors.properties', 'followers')} as actorFollowersURL
-            FROM actor_following
-            INNER JOIN actors ON actors.id = actor_following.target_actor_id
-            WHERE actor_id=? AND state='accepted'
+SELECT
+	actor_following.target_actor_id AS following_id,
+  ${db.qb.jsonExtract('actors.properties', 'followers')} AS actor_followers_url
+FROM
+	actor_following
+	INNER JOIN actors ON actors.id = actor_following.target_actor_id
+WHERE
+	actor_following.actor_id = ?1
+	AND actor_following.state = 'accepted'
         `
 		)
 		.bind(actor.id.toString())
-		.all<{ id: string; actorFollowersURL: string | null }>()
+		.all<{ following_id: string; actor_followers_url: string | null }>()
 
-	let followingIds: string[] = []
-	let followingFollowersURLs: string[] = []
+	// follow ourself to see our statuses in the our home timeline
+	const followingIds = new Set<string>([actor.id.toString()])
+	// show direct messages in the home timeline
+	const followingFollowersURLs = new Set<string>([PUBLIC_GROUP, actor.followers.toString(), actor.id.toString()])
 
-	if (following) {
-		followingIds = following.map((row) => row.id)
-		followingFollowersURLs = following.map((row) => {
-			if (row.actorFollowersURL) {
-				return row.actorFollowersURL
+	if (q1Results) {
+		for (const result of q1Results) {
+			followingIds.add(result.following_id)
+			if (result.actor_followers_url) {
+				followingFollowersURLs.add(result.actor_followers_url)
 			} else {
 				// We don't have the Actor's followers URL stored, we'll guess
 				// one.
-				return row.id + '/followers'
+				followingFollowersURLs.add(actor.id + '/followers')
 			}
-		})
+		}
 	}
 
-	// follow ourself to see our statuses in the our home timeline
-	followingIds.push(actor.id.toString())
-
 	const QUERY = `
-SELECT objects.*,
-       actors.id as actor_id,
-       actors.type as actor_type,
-       actors.pubkey as actor_pubkey,
-       actors.cdate as actor_cdate,
-       actors.properties as actor_properties,
-       actors.is_admin as actor_is_admin,
-       actors.mastodon_id as actor_mastodon_id,
-       outbox_objects.actor_id as publisher_actor_id,
-       (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
-       (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
-       (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count,
-       (SELECT count(*) > 0 FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id AND actor_reblogs.actor_id=?1) as reblogged,
-       (SELECT count(*) > 0 FROM actor_favourites WHERE actor_favourites.object_id=objects.id AND actor_favourites.actor_id=?1) as favourited
+SELECT
+  objects.id,
+  objects.mastodon_id,
+  objects.cdate,
+  objects.properties,
+
+  actors.id as actor_id,
+  actors.type as actor_type,
+  actors.pubkey as actor_pubkey,
+  actors.cdate as actor_cdate,
+  actors.properties as actor_properties,
+  actors.is_admin as actor_is_admin,
+  actors.mastodon_id as actor_mastodon_id,
+
+  outbox_objects.actor_id as publisher_actor_id,
+  outbox_objects.published_date as publisher_published,
+  outbox_objects.'to' as publisher_to,
+  outbox_objects.cc as publisher_cc,
+
+  (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
+  (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
+  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count,
+
+  (SELECT count(*) > 0 FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id AND actor_reblogs.actor_id=?1) as reblogged,
+  (SELECT count(*) > 0 FROM actor_favourites WHERE actor_favourites.object_id=objects.id AND actor_favourites.actor_id=?1) as favourited,
+
+  actor_reblogs.id as reblog_id,
+  actor_reblogs.mastodon_id as reblog_mastodon_id
 FROM outbox_objects
-INNER JOIN objects ON objects.id = outbox_objects.object_id
-INNER JOIN actors ON actors.id = outbox_objects.actor_id
+  INNER JOIN objects ON objects.id = outbox_objects.object_id
+  INNER JOIN actors ON actors.id = outbox_objects.actor_id
+  LEFT OUTER JOIN actor_reblogs ON actor_reblogs.outbox_object_id = outbox_objects.id
 WHERE
-     objects.type = 'Note'
-     AND outbox_objects.actor_id IN ${db.qb.set('?2')}
-     AND ${db.qb.jsonExtractIsNull('objects.properties', 'inReplyTo')}
-     AND (outbox_objects.target = '${PUBLIC_GROUP}' OR outbox_objects.target IN ${db.qb.set('?3')})
-GROUP BY objects.id ${db.qb.psqlOnly(', actors.id, outbox_objects.actor_id, outbox_objects.published_date')}
+  objects.type = 'Note'
+  AND outbox_objects.actor_id IN ${db.qb.set('?2')}
+  AND (${db.qb.jsonExtractIsNull('objects.properties', 'inReplyTo')}
+        OR ${db.qb.jsonExtract('objects.properties', 'inReplyTo')}
+          IN (SELECT ifnull(objects.original_object_id, objects.id)
+            FROM objects WHERE objects.original_actor_id IN ${db.qb.set('?2')}))
+  AND (EXISTS(SELECT 1 FROM json_each(outbox_objects.'to') WHERE json_each.value IN ${db.qb.set('?3')})
+        OR EXISTS(SELECT 1 FROM json_each(outbox_objects.cc) WHERE json_each.value IN ${db.qb.set('?3')}))
+${db.qb.psqlOnly('GROUP BY actors.id, outbox_objects.actor_id, outbox_objects.published_date')}
 ORDER BY ${db.qb.timeNormalize('outbox_objects.published_date')} DESC
 LIMIT ?4
 `
 	const DEFAULT_LIMIT = 20
 
-	const { success, error, results } = await db
+	const {
+		success,
+		error,
+		results: q2Results,
+	} = await db
 		.prepare(QUERY)
-		.bind(actor.id.toString(), JSON.stringify(followingIds), JSON.stringify(followingFollowersURLs), DEFAULT_LIMIT)
-		.all<{
-			mastodon_id: string
-			id: string
-			cdate: string
-			properties: string
-			actor_id: string
-			actor_type: Actor['type']
-			actor_pubkey: string | null
-			actor_cdate: string
-			actor_properties: string
-			actor_is_admin: 1 | null
-			actor_mastodon_id: string
-			publisher_actor_id: string
-			favourites_count: number
-			reblogs_count: number
-			replies_count: number
-			reblogged: 1 | 0
-			favourited: 1 | 0
-		}>()
+		.bind(
+			actor.id.toString(),
+			JSON.stringify([...followingIds]),
+			JSON.stringify([...followingFollowersURLs]),
+			DEFAULT_LIMIT
+		)
+		.all<
+			{
+				id: string
+				mastodon_id: string
+				cdate: string
+				properties: string
+
+				actor_id: string
+				actor_type: Actor['type']
+				actor_pubkey: string | null
+				actor_cdate: string
+				actor_properties: string
+				actor_is_admin: 1 | null
+				actor_mastodon_id: string
+
+				publisher_actor_id: string
+				publisher_published: string
+				publisher_to: string
+				publisher_cc: string
+
+				favourites_count: number
+				reblogs_count: number
+				replies_count: number
+
+				reblogged: 1 | 0
+				favourited: 1 | 0
+			} & ({ reblog_id: string; reblog_mastodon_id: string } | { reblog_id: null; reblog_mastodon_id: null })
+		>()
 	if (!success) {
 		throw new Error('SQL error: ' + error)
 	}
-	if (!results) {
+	if (!q2Results) {
 		return []
 	}
 
 	const out: Array<MastodonStatus> = []
 
-	for (let i = 0, len = results.length; i < len; i++) {
-		const result = results[i]
-		result.mastodon_id = await ensureObjectMastodonId(db, result.mastodon_id, result.cdate)
-
+	for (const result of q2Results) {
 		const status = await toMastodonStatusFromRow(domain, db, result)
 		if (status !== null) {
 			out.push(status)
@@ -139,59 +175,107 @@ export async function getPublicTimeline(
 	domain: string,
 	db: Database,
 	localPreference: LocalPreference,
-	offset = 0,
+	onlyMedia: boolean,
+	limit: number,
+	maxId?: string,
+	minId?: string,
 	hashtag?: string
 ): Promise<Array<MastodonStatus>> {
 	const QUERY = `
-SELECT objects.*,
-       actors.id as actor_id,
-       actors.type as actor_type,
-       actors.pubkey as actor_pubkey,
-       actors.cdate as actor_cdate,
-       actors.properties as actor_properties,
-       actors.is_admin as actor_is_admin,
-       actors.mastodon_id as actor_mastodon_id,
-       outbox_objects.actor_id as publisher_actor_id,
-       (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
-       (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
-       (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count
+SELECT
+  objects.id,
+  objects.mastodon_id,
+  objects.cdate,
+  objects.properties,
+
+  actors.id as actor_id,
+  actors.type as actor_type,
+  actors.pubkey as actor_pubkey,
+  actors.cdate as actor_cdate,
+  actors.properties as actor_properties,
+  actors.is_admin as actor_is_admin,
+  actors.mastodon_id as actor_mastodon_id,
+
+  outbox_objects.actor_id as publisher_actor_id,
+  outbox_objects.published_date as publisher_published,
+  outbox_objects.'to' as publisher_to,
+  outbox_objects.cc as publisher_cc,
+
+  (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
+  (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
+  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count,
+
+  actor_reblogs.id as reblog_id,
+  actor_reblogs.mastodon_id as reblog_mastodon_id
 FROM outbox_objects
-INNER JOIN objects ON objects.id=outbox_objects.object_id
-INNER JOIN actors ON actors.id=outbox_objects.actor_id
-LEFT JOIN note_hashtags ON objects.id=note_hashtags.object_id
-WHERE objects.type='Note'
-      AND ${localPreferenceQuery(localPreference)}
-      AND ${db.qb.jsonExtractIsNull('objects.properties', 'inReplyTo')}
-      AND outbox_objects.target = '${PUBLIC_GROUP}'
-      ${hashtag ? 'AND note_hashtags.value=?3' : ''}
-GROUP BY objects.id ${db.qb.psqlOnly(
-		', actors.id, actors.cdate, actors.properties, outbox_objects.actor_id, outbox_objects.published_date'
+  INNER JOIN objects ON objects.id=outbox_objects.object_id
+  INNER JOIN actors ON actors.id=outbox_objects.actor_id
+  LEFT JOIN note_hashtags ON objects.id=note_hashtags.object_id
+  LEFT OUTER JOIN actor_reblogs ON actor_reblogs.outbox_object_id = outbox_objects.id
+WHERE
+  objects.type='Note'
+  AND ${localPreferenceQuery(localPreference)}
+  AND ${db.qb.jsonExtractIsNull('objects.properties', 'inReplyTo')}
+  AND EXISTS(SELECT 1 FROM json_each(outbox_objects.'to') WHERE json_each.value = '${PUBLIC_GROUP}')
+  AND ${db.qb.timeNormalize('outbox_objects.cdate')} ${maxId ? '<' : '>'} ?2
+  ${maxId && minId ? 'AND ' + db.qb.timeNormalize('outbox_objects.cdate') + ' > ?3' : ''}
+  ${hashtag ? 'AND note_hashtags.value = ' + (maxId && minId ? '?4' : '?3') : ''}
+  ${onlyMedia ? `AND ${db.qb.jsonArrayLength(db.qb.jsonExtract('objects.properties', 'attachment'))} != 0` : ''}
+GROUP BY outbox_objects.id ${db.qb.psqlOnly(
+		', actors.cdate, actors.properties, outbox_objects.actor_id, outbox_objects.published_date'
 	)}
 ORDER BY ${db.qb.timeNormalize('outbox_objects.published_date')} DESC
-LIMIT ?1 OFFSET ?2
+LIMIT ?1
 `
-	const DEFAULT_LIMIT = 20
+	const bindings: [number, ...string[]] = [limit]
+	if (maxId) {
+		bindings.push(maxId)
+		if (minId) {
+			bindings.push(minId)
+		}
+		if (hashtag) {
+			bindings.push(hashtag)
+		}
+	} else if (minId) {
+		bindings.push(minId)
+		if (hashtag) {
+			bindings.push(hashtag)
+		}
+	} else {
+		bindings.push(db.qb.epoch())
+		if (hashtag) {
+			bindings.push(hashtag)
+		}
+	}
 
 	const { success, error, results } = await db
 		.prepare(QUERY)
-		.bind(...(hashtag ? [DEFAULT_LIMIT, offset, hashtag] : [DEFAULT_LIMIT, offset]))
-		.all<{
-			mastodon_id: string
-			id: string
-			cdate: string
-			properties: string
-			actor_id: string
-			actor_type: Actor['type']
-			actor_pubkey: string | null
-			actor_cdate: string
-			actor_properties: string
-			actor_is_admin: 1 | null
-			actor_mastodon_id: string
-			publisher_actor_id: string
-			favourites_count: number
-			reblogs_count: number
-			replies_count: number
-		}>()
+		.bind(...bindings)
+		.all<
+			{
+				mastodon_id: string
+				id: string
+				cdate: string
+				properties: string
+
+				actor_id: string
+				actor_type: Actor['type']
+				actor_pubkey: string | null
+				actor_cdate: string
+				actor_properties: string
+				actor_is_admin: 1 | null
+				actor_mastodon_id: string
+
+				publisher_actor_id: string
+				publisher_published: string
+				publisher_to: string
+				publisher_cc: string
+
+				favourites_count: number
+				reblogs_count: number
+				replies_count: number
+			} & ({ reblog_id: string; reblog_mastodon_id: string } | { reblog_id: null })
+		>()
 	if (!success) {
 		throw new Error('SQL error: ' + error)
 	}
@@ -201,10 +285,7 @@ LIMIT ?1 OFFSET ?2
 
 	const out: Array<MastodonStatus> = []
 
-	for (let i = 0, len = results.length; i < len; i++) {
-		const result = results[i]
-		result.mastodon_id = await ensureObjectMastodonId(db, result.mastodon_id, result.cdate)
-
+	for (const result of results) {
 		const status = await toMastodonStatusFromRow(domain, db, result)
 		if (status !== null) {
 			out.push(status)
@@ -212,4 +293,43 @@ LIMIT ?1 OFFSET ?2
 	}
 
 	return out
+}
+
+export async function getStatusRange(
+	db: Database,
+	maxId?: MastodonId,
+	minId?: MastodonId
+): Promise<[max: string | null, min: string | null]> {
+	const QUERY = `
+SELECT outbox_objects.cdate
+FROM outbox_objects
+INNER JOIN objects ON objects.id = outbox_objects.object_id
+WHERE objects.mastodon_id = ?1
+  `
+	if (maxId) {
+		const { results } = await db.prepare(QUERY).bind(maxId).all<{ cdate: string }>()
+		if (results === undefined || results.length === 0) {
+			return [null, null]
+		}
+		const [{ cdate: max }] = results
+
+		if (minId) {
+			const { results } = await db.prepare(QUERY).bind(minId).all<{ cdate: string }>()
+			if (results === undefined || results.length === 0) {
+				return [null, null]
+			}
+			const [{ cdate: min }] = results
+			return [max, min]
+		}
+		return [max, null]
+	}
+	if (minId) {
+		const { results } = await db.prepare(QUERY).bind(minId).all<{ cdate: string }>()
+		if (results === undefined || results.length === 0) {
+			return [null, null]
+		}
+		const [{ cdate: min }] = results
+		return [null, min]
+	}
+	return [null, null]
 }

--- a/backend/src/types/notification.ts
+++ b/backend/src/types/notification.ts
@@ -1,8 +1,6 @@
 import type { MastodonAccount } from 'wildebeest/backend/src/types/account'
 import type { MastodonStatus } from 'wildebeest/backend/src/types/status'
 
-import type { ObjectsRow } from './objects'
-
 export type NotificationType =
 	| 'mention'
 	| 'status'
@@ -23,11 +21,19 @@ export type Notification = {
 	status?: MastodonStatus
 }
 
-export interface NotificationsQueryResult extends ObjectsRow {
-	type: NotificationType
-	original_actor_id: URL
-	notif_from_actor_id: URL
-	notif_cdate: string
-	notif_id: URL
-	from_actor_id: string
+type ObjectRow = {
+	id: string
+	type: string
+	properties: string
+	mastodon_id: string
+	cdate: string
+	original_actor_id: string
 }
+
+export type NotificationsQueryResult = {
+	notif_actor_id: string
+	notif_type: NotificationType
+	notif_from_actor_id: string
+	notif_cdate: string
+	notif_id: string
+} & (ObjectRow | { id: null })

--- a/backend/src/types/objects.ts
+++ b/backend/src/types/objects.ts
@@ -1,6 +1,0 @@
-export interface ObjectsRow {
-	properties: string
-	mastodon_id: string
-	id: URL
-	cdate: string
-}

--- a/backend/src/types/status.ts
+++ b/backend/src/types/status.ts
@@ -17,30 +17,109 @@ type Tag = {
 	url: string
 }
 
+// https://docs.joinmastodon.org/entities/Poll/
+type Poll = {
+	id: string
+	expires_at: string | null
+	expired: boolean
+	votes_count: number
+	options: PollOption[]
+	emojis: CustomEmoji[]
+	voted?: boolean
+	own_votes?: number[]
+} & ({ multiple: true; voters_count: number } | { multiple: false; voters_count: null })
+
+type PollOption = {
+	title: string
+	votes_count: number | null
+}
+
+// https://docs.joinmastodon.org/entities/PreviewCard/
+type PreviewCard = {
+	url: URL
+	title: string
+	description: string
+	type: 'link' | 'photo' | 'video' | 'rich'
+	author_name: string
+	author_url: URL
+	provider_name: string
+	provider_url: URL
+	html: string
+	width: number
+	height: number
+	image: URL | null
+	embed_url: URL
+	blurhash: string | null
+}
+
+// https://docs.joinmastodon.org/entities/FilterResult/
+type FilterResult = {
+	filter: Filter
+	keyword_matches: string[] | null
+	status_matches: string[] | null
+}
+
+// https://docs.joinmastodon.org/entities/Filter/
+type Filter = {
+	id: string
+	title: string
+	context: 'home' | 'notifications' | 'public' | 'thread' | 'account'
+	expires_at: string | null
+	filter_action: 'warn' | 'hide'
+	keywords: FilterKeyword[]
+	statuses: FilterStatus[]
+}
+
+// https://docs.joinmastodon.org/entities/FilterKeyword/
+type FilterKeyword = {
+	id: string
+	keyword: string
+	whole_word: boolean
+}
+
+// https://docs.joinmastodon.org/entities/FilterStatus/
+type FilterStatus = {
+	id: string
+	status_id: string
+}
+
 // https://docs.joinmastodon.org/entities/Status/
 // https://github.com/mastodon/mastodon-android/blob/master/mastodon/src/main/java/org/joinmastodon/android/model/Status.java
 export type MastodonStatus = {
 	id: MastodonId
 	uri: URL
-	url: URL
 	created_at: string
 	account: MastodonAccount
 	content: string
 	visibility: Visibility
+	sensitive: boolean
 	spoiler_text: string
-	emojis: CustomEmoji[]
 	media_attachments: MediaAttachment[]
+	application?: {
+		name: string
+		website: URL | null
+	}
 	mentions: Mention[]
 	tags: Tag[]
-	favourites_count?: number
-	reblogs_count?: number
-	reblog?: MastodonStatus
-	edited_at?: string
-	replies_count?: number
-	reblogged?: boolean
+	emojis: CustomEmoji[]
+	reblogs_count: number
+	favourites_count: number
+	replies_count: number
+	url: URL | null
+	in_reply_to_id: string | null
+	in_reply_to_account_id: string | null
+	reblog: MastodonStatus | null
+	poll: Poll | null
+	card: PreviewCard | null
+	language: string | null
+	text: string | null
+	edited_at: string | null
 	favourited?: boolean
-	in_reply_to_id?: string
-	in_reply_to_account_id?: string
+	reblogged?: boolean
+	muted?: boolean
+	bookmarked?: boolean
+	pinned?: boolean
+	filtered?: FilterResult[]
 }
 
 // https://docs.joinmastodon.org/entities/Context/

--- a/backend/src/utils/index.ts
+++ b/backend/src/utils/index.ts
@@ -7,3 +7,7 @@ export * from './http'
 export function isUUID(str: string): boolean {
 	return /^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(str)
 }
+
+export function unique<T>(arr: T[]): T[] {
+	return [...new Set(arr)]
+}

--- a/backend/src/utils/type.ts
+++ b/backend/src/utils/type.ts
@@ -8,3 +8,5 @@ export type Intersect<T, U> = Exclude<keyof T, keyof U> extends never
 		? never
 		: { [P in Exclude<keyof U, keyof T>]: U[P] }
 	: { [P in Exclude<keyof T, keyof U>]: T[P] }
+
+export type AwaitedOnce<T> = T extends Promise<infer U> ? U : T

--- a/backend/test/activitypub/follow.spec.ts
+++ b/backend/test/activitypub/follow.spec.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert/strict'
 
-import { Activity, createActivityId, FollowActivity } from 'wildebeest/backend/src/activitypub/activities'
+import { Activity, FollowActivity } from 'wildebeest/backend/src/activitypub/activities'
 import * as activityHandler from 'wildebeest/backend/src/activitypub/activities/handle'
 import { createPerson } from 'wildebeest/backend/src/activitypub/actors'
 import { getApId } from 'wildebeest/backend/src/activitypub/objects'
@@ -11,7 +11,7 @@ import * as ap_followers_page from 'wildebeest/functions/ap/users/[id]/followers
 import * as ap_following from 'wildebeest/functions/ap/users/[id]/following'
 import * as ap_following_page from 'wildebeest/functions/ap/users/[id]/following/page'
 
-import { assertStatus, makeDB } from '../utils'
+import { assertStatus, createActivityId, makeDB } from '../utils'
 
 const userKEK = 'test_kek10'
 const domain = 'cloudflare.com'

--- a/backend/test/mastodon/notifications.spec.ts
+++ b/backend/test/mastodon/notifications.spec.ts
@@ -2,13 +2,13 @@ import { strict as assert } from 'node:assert/strict'
 
 import { createPerson } from 'wildebeest/backend/src/activitypub/actors'
 import { mastodonIdSymbol } from 'wildebeest/backend/src/activitypub/objects'
-import { createPublicNote } from 'wildebeest/backend/src/activitypub/objects/note'
 import { createNotification, insertFollowNotification } from 'wildebeest/backend/src/mastodon/notification'
 import { sendLikeNotification } from 'wildebeest/backend/src/mastodon/notification'
 import { getNotifications } from 'wildebeest/backend/src/mastodon/notification'
 import { createSubscription } from 'wildebeest/backend/src/mastodon/subscription'
 import { arrayBufferToBase64 } from 'wildebeest/backend/src/utils/key-ops'
 import type { JWK } from 'wildebeest/backend/src/webpush/jwk'
+import { createPublicStatus } from 'wildebeest/backend/test/shared.utils'
 import * as notifications from 'wildebeest/functions/api/v1/notifications'
 import * as notifications_get from 'wildebeest/functions/api/v1/notifications/[id]'
 
@@ -50,10 +50,7 @@ describe('Mastodon APIs', () => {
 			const fromActor = await createPerson(domain, db, userKEK, 'from@cloudflare.com')
 
 			const connectedActor = actor
-			const note = await createPublicNote(domain, db, 'my first status', connectedActor, new Set(), [], {
-				sensitive: false,
-				source: { content: 'my first status', mediaType: 'text/markdown' },
-			})
+			const note = await createPublicStatus(domain, db, connectedActor, 'my first status')
 			await insertFollowNotification(db, connectedActor, fromActor)
 			await sleep(10)
 			await createNotification(db, 'favourite', connectedActor, fromActor, note)
@@ -80,10 +77,7 @@ describe('Mastodon APIs', () => {
 			const db = await makeDB()
 			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
 			const fromActor = await createPerson(domain, db, userKEK, 'from@cloudflare.com')
-			const note = await createPublicNote(domain, db, 'my first status', actor, new Set(), [], {
-				sensitive: false,
-				source: { content: 'my first status', mediaType: 'text/markdown' },
-			})
+			const note = await createPublicStatus(domain, db, actor, 'my first status')
 			await createNotification(db, 'favourite', actor, fromActor, note)
 
 			const res = await notifications_get.handleRequest(domain, '1', db, actor)

--- a/backend/test/mastodon/tags.spec.ts
+++ b/backend/test/mastodon/tags.spec.ts
@@ -1,8 +1,8 @@
 import { strict as assert } from 'node:assert/strict'
 
 import { createPerson } from 'wildebeest/backend/src/activitypub/actors'
-import { createPublicNote } from 'wildebeest/backend/src/activitypub/objects/note'
 import { insertHashtags } from 'wildebeest/backend/src/mastodon/hashtag'
+import { createPublicStatus } from 'wildebeest/backend/test/shared.utils'
 import * as tag_id from 'wildebeest/functions/api/v1/tags/[tag]'
 
 import { assertCORS, assertStatus, isUrlValid, makeDB } from '../utils'
@@ -23,10 +23,7 @@ describe('Mastodon APIs', () => {
 			const db = await makeDB()
 			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
 
-			const note = await createPublicNote(domain, db, 'my localnote status', actor, new Set(), [], {
-				sensitive: false,
-				source: { content: 'my first status', mediaType: 'text/markdown' },
-			})
+			const note = await createPublicStatus(domain, db, actor, 'my localnote status')
 			await insertHashtags(db, note, ['test'])
 
 			const res = await tag_id.handleRequestGet(db, domain, 'test')

--- a/backend/test/shared.utils.ts
+++ b/backend/test/shared.utils.ts
@@ -7,9 +7,15 @@
 import { ApObject } from 'wildebeest/backend/src/activitypub/objects'
 import { type Database } from 'wildebeest/backend/src/database'
 
-import type { Actor, Person } from '../src/activitypub/actors'
+import { type Actor, getActorById, type Person } from '../src/activitypub/actors'
 import { addObjectInOutbox } from '../src/activitypub/actors/outbox'
-import { createPublicNote, type Note } from '../src/activitypub/objects/note'
+import {
+	createDirectNote,
+	createPrivateNote,
+	createPublicNote,
+	createUnlistedNote,
+	type Note,
+} from '../src/activitypub/objects/note'
 import { insertReply } from '../src/mastodon/reply'
 
 /**
@@ -26,10 +32,19 @@ export async function createReply(
 	db: Database,
 	actor: Actor,
 	originalNote: Note,
-	replyContent: string
+	replyContent: string,
+	sensitive: boolean = false
 ) {
-	const inReplyTo = originalNote.id
-	const replyNote = await createPublicNote(domain, db, replyContent, actor, new Set(), [], { inReplyTo } as any)
+	const inReplyTo = originalNote.id.toString()
+	const repliedActor = await getActorById(db, originalNote.attributedTo.toString())
+	if (!repliedActor) {
+		throw new Error('replied actor not found')
+	}
+	const replyNote = await createPublicNote(domain, db, replyContent, actor, new Set([repliedActor]), [], {
+		inReplyTo,
+		sensitive,
+		source: { content: replyContent, mediaType: 'text/plain' },
+	})
 	await addObjectInOutbox(db, actor, replyNote)
 	await insertReply(db, actor, replyNote, originalNote)
 }
@@ -45,7 +60,7 @@ export async function createReply(
  * @param extraProperties optional extra properties for the status
  * @returns the created Note for the status
  */
-export async function createStatus(
+export async function createPublicStatus(
 	domain: string,
 	db: Database,
 	actor: Person,
@@ -60,7 +75,75 @@ export async function createStatus(
 		actor,
 		new Set(),
 		attachments,
-		(extraProperties as any) ?? { sensitive: false, source: { content: 'test', mediaType: 'text/plain' } }
+		(extraProperties as any) ?? { sensitive: false, source: { content, mediaType: 'text/plain' } }
+	)
+	if (extraProperties?.published) {
+		await addObjectInOutbox(db, actor, note, note.to, note.cc, extraProperties.published)
+	} else {
+		await addObjectInOutbox(db, actor, note)
+	}
+	return note
+}
+
+export async function createUnlistedStatus(
+	domain: string,
+	db: Database,
+	actor: Person,
+	content: string,
+	attachments?: ApObject[],
+	extraProperties?: Record<string, any>
+) {
+	const note = await createUnlistedNote(
+		domain,
+		db,
+		content,
+		actor,
+		new Set(),
+		attachments,
+		(extraProperties as any) ?? { sensitive: false, source: { content, mediaType: 'text/plain' } }
+	)
+	await addObjectInOutbox(db, actor, note)
+	return note
+}
+
+export async function createPrivateStatus(
+	domain: string,
+	db: Database,
+	actor: Person,
+	content: string,
+	attachments?: ApObject[],
+	extraProperties?: Record<string, any>
+) {
+	const note = await createPrivateNote(
+		domain,
+		db,
+		content,
+		actor,
+		new Set(),
+		attachments,
+		(extraProperties as any) ?? { sensitive: false, source: { content, mediaType: 'text/plain' } }
+	)
+	await addObjectInOutbox(db, actor, note)
+	return note
+}
+
+export async function createDirectStatus(
+	domain: string,
+	db: Database,
+	actor: Person,
+	content: string,
+	attachments?: ApObject[],
+	extraProperties?: Record<string, any>
+) {
+	const to = extraProperties?.to ?? [actor]
+	const note = await createDirectNote(
+		domain,
+		db,
+		content,
+		actor,
+		new Set([...to]),
+		attachments,
+		(extraProperties as any) ?? { sensitive: false, source: { content, mediaType: 'text/plain' } }
 	)
 	await addObjectInOutbox(db, actor, note)
 	return note

--- a/backend/test/utils.ts
+++ b/backend/test/utils.ts
@@ -4,6 +4,7 @@ import { D1Database, D1DatabaseAPI } from '@miniflare/d1'
 import * as SQLiteDatabase from 'better-sqlite3'
 import { promises as fs } from 'fs'
 import * as path from 'path'
+import { ApObjectId } from 'wildebeest/backend/src/activitypub/objects'
 import type { Cache } from 'wildebeest/backend/src/cache'
 import { type Database } from 'wildebeest/backend/src/database'
 import d1 from 'wildebeest/backend/src/database/d1'
@@ -173,4 +174,9 @@ export function hexToBytes(hex: string): Uint8Array {
 		bytes[i] = parseInt(hex.substring(start, start + 2), 16)
 	}
 	return bytes
+}
+
+export function createActivityId(domain: string): ApObjectId {
+	const id = crypto.randomUUID()
+	return new URL('/ap/a/' + id, 'https://' + domain)
 }

--- a/consumer/test/consumer.spec.ts
+++ b/consumer/test/consumer.spec.ts
@@ -1,9 +1,9 @@
 import { strict as assert } from 'node:assert/strict'
 
 import { createPerson } from 'wildebeest/backend/src/activitypub/actors'
-import { createPublicNote } from 'wildebeest/backend/src/activitypub/objects/note'
 import type { DeliverMessageBody } from 'wildebeest/backend/src/types'
 import { MessageType } from 'wildebeest/backend/src/types'
+import { createPublicStatus } from 'wildebeest/backend/test/shared.utils'
 import { makeDB } from 'wildebeest/backend/test/utils'
 
 import { Env } from '../src'
@@ -46,10 +46,7 @@ describe('Consumer', () => {
 			}
 
 			const actor = await createPerson(domain, db, userKEK, 'sven@cloudflare.com')
-			const note = await createPublicNote(domain, db, 'my first status', actor, new Set(), [], {
-				sensitive: false,
-				source: { content: 'my first status', mediaType: 'text/plain' },
-			})
+			const note = await createPublicStatus(domain, db, actor, 'my first status')
 
 			const activity: any = {
 				type: 'Create',

--- a/frontend/mock-db/init.ts
+++ b/frontend/mock-db/init.ts
@@ -3,7 +3,7 @@ import { reblogs, replies, statuses } from 'wildebeest/frontend/src/dummyData'
 import type { Account, MastodonStatus } from 'wildebeest/frontend/src/types'
 import { Note } from 'wildebeest/backend/src/activitypub/objects/note'
 import { createReblog } from 'wildebeest/backend/src/mastodon/reblog'
-import { createReply as createReplyInBackend, createStatus } from 'wildebeest/backend/test/shared.utils'
+import { createReply as createReplyInBackend, createPublicStatus } from 'wildebeest/backend/test/shared.utils'
 import type { ApObject } from 'wildebeest/backend/src/activitypub/objects'
 import { type Database } from 'wildebeest/backend/src/database'
 import { upsertRule } from 'wildebeest/backend/src/config/rules'
@@ -16,7 +16,7 @@ export async function init(domain: string, db: Database) {
 	const loadedStatuses: { status: MastodonStatus; note: Note }[] = []
 	for (const status of statuses) {
 		const actor = await getOrCreatePerson(domain, db, status.account)
-		const note = await createStatus(
+		const note = await createPublicStatus(
 			domain,
 			db,
 			actor,
@@ -34,7 +34,7 @@ export async function init(domain: string, db: Database) {
 		if (reblogStatus?.id) {
 			const noteToReblog = loadedStatuses.find(({ status: { id } }) => id === reblogStatus.id)?.note
 			if (noteToReblog) {
-				await createReblog(db, reblogger, noteToReblog)
+				await createReblog(db, reblogger, noteToReblog, noteToReblog)
 			}
 		}
 	}

--- a/frontend/src/routes/(frontend)/[accountId]/index.tsx
+++ b/frontend/src/routes/(frontend)/[accountId]/index.tsx
@@ -23,7 +23,7 @@ export const statusesLoader = loader$<
 		const db = await getDatabase(platform)
 		mastodonId = await getMastodonIdByHandle(url.hostname, db, handle)
 		if (mastodonId) {
-			const response = await handleRequest({ domain: url.hostname, db }, mastodonId, {
+			const response = await handleRequest({ domain: url.hostname, db, connectedActor: undefined }, mastodonId, {
 				exclude_replies: true,
 
 				// default values

--- a/frontend/src/routes/(frontend)/[accountId]/with_replies/index.tsx
+++ b/frontend/src/routes/(frontend)/[accountId]/with_replies/index.tsx
@@ -24,14 +24,18 @@ export const statusesLoader = loader$<
 		const db = await getDatabase(platform)
 		mastodonId = await getMastodonIdByHandle(url.hostname, db, handle)
 		if (mastodonId) {
-			const response = await handleRequest({ domain: url.hostname, db: await getDatabase(platform) }, mastodonId, {
-				// default values
-				limit: 20,
-				only_media: false,
-				exclude_replies: false,
-				exclude_reblogs: false,
-				pinned: false,
-			})
+			const response = await handleRequest(
+				{ domain: url.hostname, db: await getDatabase(platform), connectedActor: undefined },
+				mastodonId,
+				{
+					// default values
+					limit: 20,
+					only_media: false,
+					exclude_replies: false,
+					exclude_reblogs: false,
+					pinned: false,
+				}
+			)
 			statuses = await response.json<Array<MastodonStatus>>()
 		}
 	} catch {

--- a/frontend/src/routes/(frontend)/explore/index.tsx
+++ b/frontend/src/routes/(frontend)/explore/index.tsx
@@ -10,7 +10,15 @@ import { getErrorHtml } from '~/utils/getErrorHtml/getErrorHtml'
 export const statusesLoader = loader$<Promise<MastodonStatus[]>>(async ({ platform, html }) => {
 	try {
 		// TODO: use the "trending" API endpoint here.
-		const response = await timelines.handleRequest(platform.DOMAIN, await getDatabase(platform))
+		const response = await timelines.handleRequest(
+			{ domain: platform.DOMAIN, db: await getDatabase(platform) },
+			{
+				local: false,
+				remote: false,
+				only_media: false,
+				limit: 20,
+			}
+		)
 		const results = await response.text()
 		// Manually parse the JSON to ensure that Qwik finds the resulting objects serializable.
 		return JSON.parse(results) as MastodonStatus[]

--- a/frontend/src/routes/(frontend)/public/index.tsx
+++ b/frontend/src/routes/(frontend)/public/index.tsx
@@ -11,7 +11,15 @@ import { getDatabase } from 'wildebeest/backend/src/database'
 export const statusesLoader = loader$<Promise<MastodonStatus[]>>(async ({ platform, html }) => {
 	try {
 		// TODO: use the "trending" API endpoint here.
-		const response = await timelines.handleRequest(platform.DOMAIN, await getDatabase(platform))
+		const response = await timelines.handleRequest(
+			{ domain: platform.DOMAIN, db: await getDatabase(platform) },
+			{
+				local: false,
+				remote: false,
+				only_media: false,
+				limit: 20,
+			}
+		)
 		const results = await response.text()
 		// Manually parse the JSON to ensure that Qwik finds the resulting objects serializable.
 		return JSON.parse(results) as MastodonStatus[]

--- a/frontend/src/routes/(frontend)/public/local/index.tsx
+++ b/frontend/src/routes/(frontend)/public/local/index.tsx
@@ -11,7 +11,10 @@ import { getErrorHtml } from '~/utils/getErrorHtml/getErrorHtml'
 export const statusesLoader = loader$<Promise<MastodonStatus[]>>(async ({ platform, html }) => {
 	try {
 		// TODO: use the "trending" API endpoint here.
-		const response = await timelines.handleRequest(platform.DOMAIN, await getDatabase(platform), { local: true })
+		const response = await timelines.handleRequest(
+			{ domain: platform.DOMAIN, db: await getDatabase(platform) },
+			{ local: true, remote: false, only_media: false, limit: 20 }
+		)
 		const results = await response.text()
 		// Manually parse the JSON to ensure that Qwik finds the resulting objects serializable.
 		return JSON.parse(results) as MastodonStatus[]

--- a/functions/api/v1/accounts/[id]/follow.ts
+++ b/functions/api/v1/accounts/[id]/follow.ts
@@ -80,7 +80,7 @@ export async function handleRequest(
 	}
 
 	if (await isNotFollowing(db, connectedActor, followee)) {
-		const activity = createFollowActivity(domain, connectedActor, followee)
+		const activity = await createFollowActivity(db, domain, connectedActor, followee)
 		const signingKey = await getSigningKey(userKEK, db, connectedActor)
 		await deliverToActor(signingKey, connectedActor, followee, activity, domain)
 		await addFollowing(domain, db, connectedActor, followee)

--- a/functions/api/v1/accounts/[id]/statuses.ts
+++ b/functions/api/v1/accounts/[id]/statuses.ts
@@ -1,10 +1,12 @@
 // https://docs.joinmastodon.org/methods/accounts/#statuses
 
 import { PUBLIC_GROUP } from 'wildebeest/backend/src/activitypub/activities'
-import { Actor, getActorByMastodonId } from 'wildebeest/backend/src/activitypub/actors'
+import { Actor, getActorByMastodonId, Person } from 'wildebeest/backend/src/activitypub/actors'
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
 import { resourceNotFound } from 'wildebeest/backend/src/errors'
+import { isFollowing } from 'wildebeest/backend/src/mastodon/follow'
 import { toMastodonStatusesFromRowsWithActor } from 'wildebeest/backend/src/mastodon/status'
+import { getStatusRange } from 'wildebeest/backend/src/mastodon/timeline'
 import type { ContextData, Env, MastodonId } from 'wildebeest/backend/src/types'
 import { cors, myz, readParams } from 'wildebeest/backend/src/utils'
 import { z } from 'zod'
@@ -44,11 +46,17 @@ const schema = z.object({
 type Dependencies = {
 	domain: string
 	db: Database
+	connectedActor: Person | undefined
 }
 
 type Parameters = z.infer<typeof schema>
 
-export const onRequestGet: PagesFunction<Env, 'id', ContextData> = async ({ request, env, params: { id } }) => {
+export const onRequestGet: PagesFunction<Env, 'id', Partial<ContextData>> = async ({
+	request,
+	env,
+	params: { id },
+	data,
+}) => {
 	if (typeof id !== 'string') {
 		return resourceNotFound('id', String(id))
 	}
@@ -57,23 +65,27 @@ export const onRequestGet: PagesFunction<Env, 'id', ContextData> = async ({ requ
 		return new Response('', { status: 400 })
 	}
 	const url = new URL(request.url)
-	return handleRequest({ domain: url.hostname, db: await getDatabase(env) }, id, result.data)
+	return handleRequest(
+		{ domain: url.hostname, db: await getDatabase(env), connectedActor: data?.connectedActor },
+		id,
+		result.data
+	)
 }
 
-export async function handleRequest(
-	{ domain, db }: Dependencies,
-	id: MastodonId,
-	params: Parameters
-): Promise<Response> {
-	const actor = await getActorByMastodonId(db, id)
+export async function handleRequest(deps: Dependencies, id: MastodonId, params: Parameters): Promise<Response> {
+	const actor = await getActorByMastodonId(deps.db, id)
 	if (actor) {
-		return await getStatuses(domain, db, actor, params)
+		return await getStatuses(deps, actor, params)
 	}
 	return resourceNotFound('id', id)
 }
 
-// TODO: support onlyMedia,excludeReblogs,tagged parameter
-async function getStatuses(domain: string, db: Database, actor: Actor, params: Parameters): Promise<Response> {
+// TODO: support tagged parameter
+async function getStatuses(
+	{ domain, db, connectedActor }: Dependencies,
+	actor: Actor,
+	params: Parameters
+): Promise<Response> {
 	if (params.pinned) {
 		// TODO: pinned statuses are not implemented yet. Stub the endpoint
 		// to avoid returning statuses that aren't pinned.
@@ -83,37 +95,22 @@ async function getStatuses(domain: string, db: Database, actor: Actor, params: P
 	// Client asked to retrieve statuses using max_id or (max_id and since_id) or min_id
 	// As opposed to Mastodon we don't use incremental ID but UUID, we need
 	// to retrieve the cdate of the xxx_id row and only show the specific statuses.
-	const CDATE_QUERY = `
-SELECT outbox_objects.cdate
-FROM outbox_objects
-INNER JOIN objects ON objects.id = outbox_objects.object_id
-WHERE objects.mastodon_id = ?1
-`
-	let cdate: string = db.qb.epoch()
-	let since: string | null = null
-	if (params.max_id) {
-		const { results } = await db.prepare(CDATE_QUERY).bind(params.max_id).all<{ cdate: string }>()
-		if (results === undefined || results.length === 0) {
-			return resourceNotFound('max_id', params.max_id)
-		}
-		cdate = results[0].cdate
+	const [max, min] = await getStatusRange(db, params.max_id, params.since_id ?? params.min_id)
+	if (params.max_id && max === null) {
+		return resourceNotFound('max_id', params.max_id)
+	}
+	if (params.since_id && min === null) {
+		return resourceNotFound('since_id', params.since_id)
+	}
+	if (params.min_id && min === null) {
+		return resourceNotFound('min_id', params.min_id)
+	}
 
-		const sinceId = params.since_id || params.min_id
-		if (sinceId) {
-			const { results } = await db.prepare(CDATE_QUERY).bind(sinceId).all<{ cdate: string }>()
-			if (results === undefined || results.length === 0) {
-				return resourceNotFound(params.since_id ? 'since_id' : 'min_id', sinceId)
-			}
-			since = results[0].cdate
-		}
-	} else {
-		const minId = params.min_id || params.since_id
-		if (minId) {
-			const { results } = await db.prepare(CDATE_QUERY).bind(minId).all<{ cdate: string }>()
-			if (results === undefined || results.length === 0) {
-				return resourceNotFound('min_id', minId)
-			}
-			cdate = results[0].cdate
+	const targets = [PUBLIC_GROUP]
+	if (connectedActor) {
+		targets.push(connectedActor.id.toString())
+		if (await isFollowing(db, connectedActor, actor)) {
+			targets.push(actor.followers.toString())
 		}
 	}
 
@@ -121,38 +118,63 @@ WHERE objects.mastodon_id = ?1
 		.prepare(
 			`
 SELECT
-  objects.*,
+  objects.id,
+  objects.mastodon_id,
+  objects.cdate,
+  objects.properties,
+
   outbox_objects.actor_id as publisher_actor_id,
+  outbox_objects.published_date as publisher_published,
+  outbox_objects.'to' as publisher_to,
+  outbox_objects.cc as publisher_cc,
+
   (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
   (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
-  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count
+  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count,
+
+  actor_reblogs.id as reblog_id,
+	actor_reblogs.mastodon_id as reblog_mastodon_id
 FROM outbox_objects
-INNER JOIN objects ON objects.id = outbox_objects.object_id
+  INNER JOIN objects ON objects.id = outbox_objects.object_id
+  LEFT OUTER JOIN actor_reblogs ON actor_reblogs.outbox_object_id = outbox_objects.id
 WHERE
   objects.type = 'Note'
-  ${params.exclude_replies ? 'AND ' + db.qb.jsonExtractIsNull('objects.properties', 'inReplyTo') : ''}
-  AND outbox_objects.target = '${PUBLIC_GROUP}'
   AND outbox_objects.actor_id = ?1
-  AND ${db.qb.timeNormalize('outbox_objects.cdate')} ${params.max_id ? '<' : '>'} ?2
-  ${params.max_id && since ? 'AND ' + db.qb.timeNormalize('outbox_objects.cdate') + ' > ?4' : ''}
+  ${params.exclude_replies ? `AND ${db.qb.jsonExtractIsNull('objects.properties', 'inReplyTo')}` : ''}
+  AND (EXISTS(SELECT 1 FROM json_each(outbox_objects.'to') WHERE json_each.value IN ${db.qb.set('?2')})
+        OR EXISTS(SELECT 1 FROM json_each(outbox_objects.cc) WHERE json_each.value IN ${db.qb.set('?2')}))
+  AND ${db.qb.timeNormalize('outbox_objects.cdate')} ${max ? '<' : '>'} ?3
+  ${max && min ? 'AND ' + db.qb.timeNormalize('outbox_objects.cdate') + ' > ?5' : ''}
+  ${params.exclude_reblogs ? 'AND actor_reblogs.id IS NULL' : ''}
+  ${params.only_media ? `AND ${db.qb.jsonArrayLength(db.qb.jsonExtract('objects.properties', 'attachment'))} != 0` : ''}
 ORDER BY ${db.qb.timeNormalize('outbox_objects.published_date')} DESC
-LIMIT ?3
+LIMIT ?4
   `
 		)
 		.bind(
-			...(params.max_id && since
-				? [actor.id.toString(), cdate, params.limit, since]
-				: [actor.id.toString(), cdate, params.limit])
+			...(max && min
+				? [actor.id.toString(), JSON.stringify(targets), max, params.limit, min]
+				: min
+				? [actor.id.toString(), JSON.stringify(targets), max ?? db.qb.epoch(), params.limit, min]
+				: [actor.id.toString(), JSON.stringify(targets), max ?? db.qb.epoch(), params.limit])
 		)
 		.all<{
-			mastodon_id: string
 			id: string
+			mastodon_id: string
 			cdate: string
 			properties: string
+
 			publisher_actor_id: string
+			publisher_published: string
+			publisher_to: string
+			publisher_cc: string
+
 			favourites_count: number
 			reblogs_count: number
 			replies_count: number
+
+			reblog_id: string | null
+			reblog_mastodon_id: string | null
 		}>()
 	if (!success) {
 		throw new Error('SQL error: ' + error)

--- a/functions/api/v1/accounts/[id]/unfollow.ts
+++ b/functions/api/v1/accounts/[id]/unfollow.ts
@@ -54,7 +54,7 @@ export async function handleRequest(
 	}
 
 	if (await isFollowingOrFollowingRequested(db, connectedActor, targetActor)) {
-		const activity = createUnfollowActivity(domain, connectedActor, targetActor)
+		const activity = await createUnfollowActivity(db, domain, connectedActor, targetActor)
 		const signingKey = await getSigningKey(userKEK, db, connectedActor)
 		await deliverToActor<UndoActivity>(signingKey, connectedActor, targetActor, activity, domain)
 		await removeFollowing(db, connectedActor, targetActor)

--- a/functions/api/v1/accounts/update_credentials.ts
+++ b/functions/api/v1/accounts/update_credentials.ts
@@ -119,7 +119,7 @@ export async function handleRequest(
 		}
 
 		// send updates
-		const activity = createUpdateActivity(domain, connectedActor, actor)
+		const activity = await createUpdateActivity(db, domain, connectedActor, actor)
 		await deliverFollowers(db, userKEK, connectedActor, activity, queue)
 
 		return new Response(JSON.stringify(res), { headers })

--- a/functions/api/v1/notifications/[id].ts
+++ b/functions/api/v1/notifications/[id].ts
@@ -1,10 +1,15 @@
 // https://docs.joinmastodon.org/methods/notifications/#get-one
 
+import { isLocalAccount } from 'wildebeest/backend/src/accounts/getAccount'
 import type { Person } from 'wildebeest/backend/src/activitypub/actors'
 import { getActorById } from 'wildebeest/backend/src/activitypub/actors'
 import { ensureObjectMastodonId } from 'wildebeest/backend/src/activitypub/objects'
+import { Note } from 'wildebeest/backend/src/activitypub/objects/note'
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
+import { statusNotFound } from 'wildebeest/backend/src/errors'
 import { loadMastodonAccount } from 'wildebeest/backend/src/mastodon/account'
+import { actorToMention, detectVisibility } from 'wildebeest/backend/src/mastodon/status'
+import { fromObject } from 'wildebeest/backend/src/media'
 import type { ContextData, Env } from 'wildebeest/backend/src/types'
 import type { Notification, NotificationsQueryResult } from 'wildebeest/backend/src/types/notification'
 import { actorToHandle, handleToAcct } from 'wildebeest/backend/src/utils/handle'
@@ -13,9 +18,12 @@ const headers = {
 	'content-type': 'application/json; charset=utf-8',
 }
 
-export const onRequest: PagesFunction<Env, any, ContextData> = async ({ data, request, env, params }) => {
+export const onRequest: PagesFunction<Env, 'id', ContextData> = async ({ data, request, env, params: { id } }) => {
+	if (typeof id !== 'string') {
+		return statusNotFound('id')
+	}
 	const domain = new URL(request.url).hostname
-	return handleRequest(domain, params.id as string, await getDatabase(env), data.connectedActor)
+	return handleRequest(domain, id, await getDatabase(env), data.connectedActor)
 }
 
 export async function handleRequest(
@@ -25,22 +33,24 @@ export async function handleRequest(
 	connectedActor: Person
 ): Promise<Response> {
 	const query = `
-        SELECT
-            objects.*,
-            actor_notifications.type,
-            actor_notifications.actor_id,
-            actor_notifications.from_actor_id,
-            actor_notifications.cdate as notif_cdate,
-            actor_notifications.id as notif_id
-        FROM actor_notifications
-        LEFT JOIN objects ON objects.id=actor_notifications.object_id
-        WHERE actor_notifications.id=? AND actor_notifications.actor_id=?
+SELECT
+  objects.*,
+  actor_notifications.type as notif_type,
+  actor_notifications.actor_id as notif_actor_id,
+  actor_notifications.from_actor_id as notif_from_actor_id,
+  actor_notifications.cdate as notif_cdate,
+  actor_notifications.id as notif_id
+FROM actor_notifications
+LEFT JOIN objects ON objects.id=actor_notifications.object_id
+WHERE actor_notifications.id=? AND actor_notifications.actor_id=?
     `
 
 	const row = await db.prepare(query).bind(id, connectedActor.id.toString()).first<NotificationsQueryResult>()
-	row.mastodon_id = await ensureObjectMastodonId(db, row.mastodon_id, row.cdate)
+	if (!row) {
+		return statusNotFound('notification')
+	}
 
-	const from_actor_id = new URL(row.from_actor_id)
+	const from_actor_id = new URL(row.notif_from_actor_id)
 	const fromActor = await getActorById(db, from_actor_id)
 	if (!fromActor) {
 		throw new Error('unknown from actor')
@@ -51,34 +61,79 @@ export async function handleRequest(
 
 	const out: Notification = {
 		id: row.notif_id.toString(),
-		type: row.type,
+		type: row.notif_type,
 		created_at: new Date(row.notif_cdate).toISOString(),
 		account: fromAccount,
 	}
 
-	if (row.type === 'mention' || row.type === 'favourite') {
-		const properties = JSON.parse(row.properties)
+	if (row.notif_type === 'mention' || row.notif_type === 'favourite') {
+		if (row.id === null || row.type !== 'Note') {
+			throw new Error('notification object is null')
+		}
+
+		row.mastodon_id = await ensureObjectMastodonId(db, row.mastodon_id, row.cdate)
+
+		let properties
+		if (typeof row.properties === 'object') {
+			// neon uses JSONB for properties which is returned as a deserialized
+			// object.
+			properties = row.properties as Note
+		} else {
+			// D1 uses a string for JSON properties
+			properties = JSON.parse(row.properties) as Note
+		}
+
+		const mediaAttachments = Array.isArray(properties.attachment)
+			? properties.attachment.map((doc) => fromObject(doc))
+			: []
+
+		const mentions = []
+		for (const link of properties.tag ?? []) {
+			if (link.type === 'Mention') {
+				const target = fromActor.id.toString() === link.href.toString() ? fromActor : await getActorById(db, link.href)
+				if (target) {
+					mentions.push(actorToMention(domain, target))
+				}
+			}
+		}
 
 		out.status = {
 			id: row.mastodon_id,
-			content: properties.content,
-			uri: row.id,
-			url: new URL(`/@${handleToAcct(fromHandle, domain)}/${row.mastodon_id}`, 'https://' + domain),
-			created_at: new Date(row.cdate).toISOString(),
-
-			emojis: [],
-			media_attachments: [],
-			tags: [],
-			mentions: [],
-			spoiler_text: properties.spoiler_text ?? '',
-
-			// TODO: a shortcut has been taked. We assume that the actor
+			uri: new URL(row.id),
+			created_at: new Date(properties.published ?? row.cdate).toISOString(),
+			// TODO: a shortcut has been taken. We assume that the actor
 			// generating the notification also created the object. In practice
 			// likely true but not guarantee.
 			account: fromAccount,
+			content: properties.content,
+			visibility: detectVisibility({ to: properties.to, cc: properties.cc, followers: fromActor.followers }),
+			sensitive: properties.sensitive,
+			spoiler_text: properties.spoiler_text ?? '',
+			media_attachments: mediaAttachments,
+			mentions,
+			url: properties.url
+				? new URL(properties.url)
+				: isLocalAccount(domain, fromHandle)
+				? new URL(`/@${handleToAcct(fromHandle, domain)}/${row.mastodon_id}`, 'https://' + domain)
+				: new URL(row.id),
+			reblog: null,
+			edited_at: properties.updated ? new Date(properties.updated).toISOString() : null,
 
 			// TODO: stub values
-			visibility: 'public',
+			reblogs_count: 0,
+			favourites_count: 0,
+			replies_count: 0,
+			tags: [],
+			emojis: [],
+			favourited: false,
+			reblogged: false,
+			in_reply_to_id: null,
+			in_reply_to_account_id: null,
+			poll: null,
+			card: null,
+			language: null,
+			text: null,
+			// muted, bookmarked, pinned, filtered
 		}
 	}
 

--- a/functions/api/v1/statuses.ts
+++ b/functions/api/v1/statuses.ts
@@ -6,7 +6,6 @@ import { addObjectInOutbox } from 'wildebeest/backend/src/activitypub/actors/out
 import { deliverFollowers, deliverToActor } from 'wildebeest/backend/src/activitypub/deliver'
 import {
 	Document,
-	getApId,
 	getObjectByMastodonId,
 	isDocument,
 	originalObjectIdSymbol,
@@ -172,6 +171,9 @@ export async function handleRequest(
 	} else if (params.visibility === 'private') {
 		createFn = createPrivateNote
 	} else if (params.visibility === 'direct') {
+		if (mentions.size === 0) {
+			return validationError('direct messages must have at least one mention')
+		}
 		createFn = createDirectNote
 	} else {
 		return validationError(`status with visibility: ${params.visibility}`)
@@ -192,11 +194,9 @@ export async function handleRequest(
 	const activity = await createCreateActivity(db, domain, connectedActor, note)
 
 	const to = Array.isArray(activity.to) ? activity.to : [activity.to]
-	for (const target of to) {
-		await addObjectInOutbox(db, connectedActor, note, note.published, getApId(target).toString())
-	}
-
 	const cc = Array.isArray(activity.cc) ? activity.cc : [activity.cc]
+	await addObjectInOutbox(db, connectedActor, note, activity.to, activity.cc, note.published)
+
 	const followersUrl = connectedActor.followers.toString()
 	if (cc.includes(followersUrl) || to.includes(followersUrl)) {
 		await deliverFollowers(db, userKEK, connectedActor, activity, queue)

--- a/functions/api/v1/statuses.ts
+++ b/functions/api/v1/statuses.ts
@@ -189,7 +189,7 @@ export async function handleRequest(
 		await insertReply(db, connectedActor, note, inReplyToObject)
 	}
 
-	const activity = createCreateActivity(domain, connectedActor, note)
+	const activity = await createCreateActivity(db, domain, connectedActor, note)
 
 	const to = Array.isArray(activity.to) ? activity.to : [activity.to]
 	for (const target of to) {

--- a/functions/api/v1/statuses/[id].ts
+++ b/functions/api/v1/statuses/[id].ts
@@ -79,7 +79,7 @@ export async function handleRequestDelete(
 	queue: Queue<DeliverMessageBody>,
 	cache: Cache
 ): Promise<Response> {
-	const obj = (await getObjectByMastodonId(db, id)) as Note
+	const obj = await getObjectByMastodonId<Note>(db, id)
 	if (obj === null) {
 		return errors.statusNotFound(id)
 	}
@@ -95,7 +95,7 @@ export async function handleRequestDelete(
 	await deleteObject(db, obj)
 
 	// FIXME: deliver a Delete message to our peers
-	const activity = createDeleteActivity(domain, connectedActor, obj)
+	const activity = await createDeleteActivity(db, domain, connectedActor, obj)
 	await deliverFollowers(db, userKEK, connectedActor, activity, queue)
 
 	await timeline.pregenerateTimelines(domain, db, cache, connectedActor)

--- a/functions/api/v1/statuses/[id]/favourite.ts
+++ b/functions/api/v1/statuses/[id]/favourite.ts
@@ -43,7 +43,7 @@ export async function handleRequest(
 			return new Response(`target Actor ${obj[originalActorIdSymbol]} not found`, { status: 404 })
 		}
 
-		const activity = createLikeActivity(domain, connectedActor, new URL(obj[originalObjectIdSymbol]))
+		const activity = await createLikeActivity(db, domain, connectedActor, new URL(obj[originalObjectIdSymbol]))
 		const signingKey = await getSigningKey(userKEK, db, connectedActor)
 		await deliverToActor(signingKey, connectedActor, targetActor, activity, domain)
 	}

--- a/functions/api/v1/statuses/[id]/reblog.ts
+++ b/functions/api/v1/statuses/[id]/reblog.ts
@@ -1,21 +1,55 @@
 // https://docs.joinmastodon.org/methods/statuses/#boost
+import { PUBLIC_GROUP } from 'wildebeest/backend/src/activitypub/activities'
 import { createAnnounceActivity } from 'wildebeest/backend/src/activitypub/activities/announce'
 import type { Person } from 'wildebeest/backend/src/activitypub/actors'
 import * as actors from 'wildebeest/backend/src/activitypub/actors'
 import { deliverFollowers, deliverToActor } from 'wildebeest/backend/src/activitypub/deliver'
-import { getObjectByMastodonId } from 'wildebeest/backend/src/activitypub/objects'
+import { getApId, getObjectByMastodonId } from 'wildebeest/backend/src/activitypub/objects'
 import { originalActorIdSymbol, originalObjectIdSymbol } from 'wildebeest/backend/src/activitypub/objects'
 import type { Note } from 'wildebeest/backend/src/activitypub/objects/note'
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
+import { recordNotFound } from 'wildebeest/backend/src/errors'
 import { getSigningKey } from 'wildebeest/backend/src/mastodon/account'
 import { createReblog } from 'wildebeest/backend/src/mastodon/reblog'
 import { toMastodonStatusFromObject } from 'wildebeest/backend/src/mastodon/status'
-import type { ContextData, DeliverMessageBody, Env, Queue } from 'wildebeest/backend/src/types'
+import type { ContextData, DeliverMessageBody, Env, Queue, Visibility } from 'wildebeest/backend/src/types'
+import { readBody } from 'wildebeest/backend/src/utils'
 import { cors } from 'wildebeest/backend/src/utils/cors'
+import { z } from 'zod'
 
-export const onRequest: PagesFunction<Env, any, ContextData> = async ({ env, data, params, request }) => {
-	const domain = new URL(request.url).hostname
-	return handleRequest(await getDatabase(env), params.id as string, data.connectedActor, env.userKEK, env.QUEUE, domain)
+const schema = z.object({
+	visibility: z
+		.union([z.literal('public'), z.literal('unlisted'), z.literal('private'), z.literal('direct')])
+		.default('public'),
+})
+
+type Parameters = z.infer<typeof schema>
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+export const onRequest: PagesFunction<Env, 'id', ContextData> = async ({ env, data, params: { id }, request }) => {
+	if (typeof id !== 'string') {
+		return new Response('', { status: 400 })
+	}
+
+	const result = await readBody(request, schema)
+	if (!result.success) {
+		return new Response('', { status: 400 })
+	}
+
+	const url = new URL(request.url)
+	return handleRequest(
+		await getDatabase(env),
+		id,
+		data.connectedActor,
+		env.userKEK,
+		env.QUEUE,
+		url.hostname,
+		result.data
+	)
 }
 
 export async function handleRequest(
@@ -24,28 +58,50 @@ export async function handleRequest(
 	connectedActor: Person,
 	userKEK: string,
 	queue: Queue<DeliverMessageBody>,
-	domain: string
+	domain: string,
+	{ visibility }: Parameters
 ): Promise<Response> {
 	const obj = await getObjectByMastodonId<Note>(db, id)
-	if (obj === null) {
-		return new Response('', { status: 404 })
+	if (obj === null || reblogNotAllowed(connectedActor, obj, visibility)) {
+		return recordNotFound(`object ${id} not found`)
 	}
 
 	const status = await toMastodonStatusFromObject(db, obj, domain)
 	if (status === null) {
-		return new Response('', { status: 404 })
+		return recordNotFound(`object ${id} not found`)
 	}
 
-	if (obj[originalObjectIdSymbol] && obj[originalActorIdSymbol]) {
-		// Rebloggin an external object delivers the announce activity to the
-		// post author.
+	const to = new Set<string>()
+	const cc = new Set<string>()
+	if (visibility === 'public') {
+		to.add(PUBLIC_GROUP)
+		cc.add(connectedActor.followers.toString())
+		if (obj.attributedTo) {
+			cc.add(getApId(obj.attributedTo).toString())
+		}
+	} else if (visibility === 'unlisted') {
+		to.add(connectedActor.followers.toString())
+		cc.add(PUBLIC_GROUP)
+		if (obj.attributedTo) {
+			cc.add(getApId(obj.attributedTo).toString())
+		}
+	} else if (visibility === 'private') {
+		to.add(connectedActor.followers.toString())
+		if (obj.attributedTo) {
+			cc.add(getApId(obj.attributedTo).toString())
+		}
+	}
+
+	let activity
+	if (obj[originalObjectIdSymbol]) {
+		// Reblogging an external object delivers the announce activity to the post author.
 		const targetActor = await actors.getAndCache(new URL(obj[originalActorIdSymbol]), db)
-		if (!targetActor) {
-			return new Response(`target Actor ${obj[originalActorIdSymbol]} not found`, { status: 404 })
+		if (targetActor === null) {
+			return recordNotFound(`target Actor ${obj[originalActorIdSymbol]} not found`)
 		}
 
-		const activity = createAnnounceActivity(domain, connectedActor, new URL(obj[originalObjectIdSymbol]))
 		const signingKey = await getSigningKey(userKEK, db, connectedActor)
+		activity = await createAnnounceActivity(db, domain, connectedActor, new URL(obj[originalObjectIdSymbol]), to, cc)
 
 		await Promise.all([
 			// Delivers the announce activity to the post author.
@@ -53,14 +109,35 @@ export async function handleRequest(
 			// Share reblogged by delivering the announce activity to followers
 			deliverFollowers(db, userKEK, connectedActor, activity, queue),
 		])
+	} else {
+		activity = await createAnnounceActivity(db, domain, connectedActor, new URL(obj.id), to, cc)
 	}
 
-	await createReblog(db, connectedActor, obj)
+	await createReblog(db, connectedActor, obj, activity, activity.published ?? new Date().toISOString())
 	status.reblogged = true
 
-	const headers = {
-		...cors(),
-		'content-type': 'application/json; charset=utf-8',
-	}
 	return new Response(JSON.stringify(status), { headers })
+}
+
+function reblogNotAllowed(actor: Person, obj: Note, visibility: Visibility): boolean {
+	const to = (Array.isArray(obj.to) ? obj.to : [obj.to]).map((target) => getApId(target).toString())
+	const cc = (Array.isArray(obj.cc) ? obj.cc : [obj.cc]).map((target) => getApId(target).toString())
+
+	if (actor.id.toString() !== getApId(obj.attributedTo).toString()) {
+		return !(to.includes(PUBLIC_GROUP) || cc.includes(PUBLIC_GROUP))
+	}
+
+	// self reblog
+
+	// public or unlisted status -> allowed all visibility
+	if (to.includes(PUBLIC_GROUP) || cc.includes(PUBLIC_GROUP)) {
+		return false
+	}
+
+	// private status -> allowed only to followers
+	if (to.includes(actor.followers.toString())) {
+		return visibility === 'public' || visibility === 'unlisted'
+	}
+
+	return visibility === 'direct'
 }

--- a/functions/api/v1/timelines/public.ts
+++ b/functions/api/v1/timelines/public.ts
@@ -1,38 +1,66 @@
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
-import { getPublicTimeline, LocalPreference } from 'wildebeest/backend/src/mastodon/timeline'
+import { resourceNotFound } from 'wildebeest/backend/src/errors'
+import { getPublicTimeline, getStatusRange, LocalPreference } from 'wildebeest/backend/src/mastodon/timeline'
 import type { ContextData, Env } from 'wildebeest/backend/src/types'
-import { cors } from 'wildebeest/backend/src/utils/cors'
+import { cors, myz, readParams } from 'wildebeest/backend/src/utils'
+import { z } from 'zod'
 
 const headers = {
 	...cors(),
 	'content-type': 'application/json; charset=utf-8',
 }
 
-export const onRequest: PagesFunction<Env, any, ContextData> = async ({ request, env }) => {
-	const { searchParams } = new URL(request.url)
-	const local = searchParams.get('local') === 'true'
-	const remote = searchParams.get('remote') === 'true'
-	const only_media = searchParams.get('only_media') === 'true'
-	const offset = Number.parseInt(searchParams.get('offset') ?? '0')
-	const domain = new URL(request.url).hostname
-	return handleRequest(domain, await getDatabase(env), { local, remote, only_media, offset })
+const schema = z.object({
+	local: myz.logical().catch(false),
+	remote: myz.logical().catch(false),
+	only_media: myz.logical().catch(false),
+	max_id: z.string().optional(),
+	since_id: z.string().optional(),
+	min_id: z.string().optional(),
+	limit: z.coerce.number().int().min(1).max(40).catch(20),
+})
+
+type Parameters = z.infer<typeof schema>
+
+type Dependencies = {
+	domain: string
+	db: Database
 }
 
-export async function handleRequest(
-	domain: string,
-	db: Database,
-	// TODO: use only_media
-	// eslint-disable-next-line unused-imports/no-unused-vars
-	{ local = false, remote = false, only_media = false, offset = 0 } = {}
-): Promise<Response> {
-	let localParam = LocalPreference.NotSet
-	if (local) {
-		localParam = LocalPreference.OnlyLocal
-	} else if (remote) {
-		localParam = LocalPreference.OnlyRemote
+export const onRequest: PagesFunction<Env, '', ContextData> = async ({ request, env }) => {
+	const result = await readParams(request, schema)
+	if (result.success) {
+		return handleRequest({ domain: new URL(request.url).hostname, db: await getDatabase(env) }, result.data)
+	}
+	return new Response('', { status: 400 })
+}
+
+export async function handleRequest({ domain, db }: Dependencies, params: Parameters): Promise<Response> {
+	const localPreference = params.local
+		? LocalPreference.OnlyLocal
+		: params.remote
+		? LocalPreference.OnlyRemote
+		: LocalPreference.NotSet
+
+	const [max, min] = await getStatusRange(db, params.max_id, params.since_id ?? params.min_id)
+	if (params.max_id && max === null) {
+		return resourceNotFound('max_id', params.max_id)
+	}
+	if (params.since_id && min === null) {
+		return resourceNotFound('since_id', params.since_id)
+	}
+	if (params.min_id && min === null) {
+		return resourceNotFound('min_id', params.min_id)
 	}
 
-	// TODO - use only media option
-	const statuses = await getPublicTimeline(domain, db, localParam, offset)
+	const statuses = await getPublicTimeline(
+		domain,
+		db,
+		localPreference,
+		false,
+		params.limit,
+		max ?? undefined,
+		min ?? undefined
+	)
 	return new Response(JSON.stringify(statuses), { headers })
 }

--- a/functions/api/v1/timelines/tag/[tag].ts
+++ b/functions/api/v1/timelines/tag/[tag].ts
@@ -11,23 +11,25 @@ const headers = {
 
 export const onRequest: PagesFunction<Env, any, ContextData> = async ({ request, env, params }) => {
 	const url = new URL(request.url)
-	const { searchParams } = url
-	const offset = Number.parseInt(searchParams.get('offset') ?? '0')
-	return handleRequest(await getDatabase(env), request, getDomain(url), params.tag as string, offset)
+	return handleRequest(await getDatabase(env), request, getDomain(url), params.tag as string)
 }
 
-export async function handleRequest(
-	db: Database,
-	request: Request,
-	domain: string,
-	tag: string,
-	offset = 0
-): Promise<Response> {
+export async function handleRequest(db: Database, request: Request, domain: string, tag: string): Promise<Response> {
+	// FIXME: handle query params
 	const url = new URL(request.url)
 	if (url.searchParams.has('max_id')) {
 		return new Response(JSON.stringify([]), { headers })
 	}
 
-	const timeline = await timelines.getPublicTimeline(domain, db, timelines.LocalPreference.NotSet, offset, tag)
+	const timeline = await timelines.getPublicTimeline(
+		domain,
+		db,
+		timelines.LocalPreference.NotSet,
+		false,
+		20,
+		undefined,
+		undefined,
+		tag
+	)
 	return new Response(JSON.stringify(timeline), { headers })
 }

--- a/migrations/0015_add_actor_activities.sql
+++ b/migrations/0015_add_actor_activities.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS actor_activities (
+    id TEXT NOT NULL PRIMARY KEY,
+    actor_id TEXT NOT NULL,
+    type TEXT NOT NULL GENERATED ALWAYS AS (json_extract(activity, '$.type')) STORED,
+    cdate DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+    activity TEXT NOT NULL,
+
+    FOREIGN KEY(actor_id) REFERENCES actors(id) ON DELETE CASCADE
+);

--- a/migrations/0016_change_outbox_objects.sql
+++ b/migrations/0016_change_outbox_objects.sql
@@ -1,0 +1,24 @@
+CREATE TABLE new_outbox_objects (
+  id TEXT NOT NULL PRIMARY KEY,
+  actor_id TEXT NOT NULL,
+  object_id TEXT NOT NULL,
+  cdate DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+  published_date DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+  `to` TEXT NOT NULL DEFAULT (json_array()),
+  cc TEXT NOT NULL DEFAULT (json_array()),
+
+  FOREIGN KEY(actor_id)  REFERENCES actors(id) ON DELETE CASCADE,
+  FOREIGN KEY(object_id) REFERENCES objects(id) ON DELETE CASCADE
+);
+
+INSERT INTO new_outbox_objects (id, actor_id, object_id, cdate, published_date, `to`)
+SELECT id, actor_id, object_id, cdate, published_date, json_array(target) FROM outbox_objects;
+
+PRAGMA foreign_keys = false;
+DROP TABLE outbox_objects;
+ALTER TABLE new_outbox_objects RENAME TO outbox_objects;
+PRAGMA foreign_keys = true;
+
+CREATE INDEX IF NOT EXISTS outbox_objects_actor_id ON outbox_objects(actor_id);
+CREATE INDEX IF NOT EXISTS outbox_objects_to ON outbox_objects(`to`);
+CREATE INDEX IF NOT EXISTS outbox_objects_cc ON outbox_objects(cc);

--- a/migrations/0017_change_actor_reblogs.sql
+++ b/migrations/0017_change_actor_reblogs.sql
@@ -1,0 +1,46 @@
+CREATE TABLE new_actor_reblogs (
+  id TEXT NOT NULL PRIMARY KEY,
+  mastodon_id TEXT UNIQUE NOT NULL,
+  actor_id TEXT NOT NULL,
+  object_id TEXT NOT NULL,
+  outbox_object_id TEXT UNIQUE NOT NULL,
+  cdate DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+
+  UNIQUE(actor_id, object_id),
+  FOREIGN KEY(actor_id)  REFERENCES actors(id) ON DELETE CASCADE,
+  FOREIGN KEY(object_id) REFERENCES objects(id) ON DELETE CASCADE,
+  FOREIGN KEY(outbox_object_id) REFERENCES outbox_objects(id) ON DELETE CASCADE
+);
+
+-- D1 does not support transactions, so between the execution of the migration and
+-- the deployment of the Workers, it will not be possible to receive or post reblogs.
+
+-- Ideally, the id of the received or created announce activity should be inserted,
+-- but since it was not retained, the URL is made to look appropriate even though it cannot be accessed.
+-- And this query probably won't work in PostgreSQL.
+INSERT INTO new_actor_reblogs (id, mastodon_id, actor_id, object_id, outbox_object_id, cdate)
+SELECT
+	'https://' || substr(
+		tmp.object_id,
+		instr(tmp.object_id, '//') + 2,
+		instr(substr(tmp.object_id, instr(tmp.object_id, '//') + 2), '/') - 1
+	) || '/ap/a/' || actor_reblogs.id AS id,
+	actor_reblogs.id AS mastodon_id,
+	actor_reblogs.actor_id,
+	actor_reblogs.object_id,
+	tmp.id AS outbox_object_id,
+	actor_reblogs.cdate
+FROM actor_reblogs
+INNER JOIN (
+	SELECT *, ROW_NUMBER() OVER (PARTITION BY actor_id, object_id ORDER BY cdate DESC) AS rn
+	FROM outbox_objects
+) tmp ON tmp.actor_id = actor_reblogs.actor_id AND tmp.object_id = actor_reblogs.object_id
+WHERE tmp.rn = 1;
+
+PRAGMA foreign_keys = false;
+DROP TABLE actor_reblogs;
+ALTER TABLE new_actor_reblogs RENAME TO actor_reblogs;
+PRAGMA foreign_keys = true;
+
+CREATE INDEX IF NOT EXISTS actor_reblogs_actor_id ON actor_reblogs(actor_id);
+CREATE INDEX IF NOT EXISTS actor_reblogs_object_id ON actor_reblogs(object_id);

--- a/ui-e2e-tests/explore-page.spec.ts
+++ b/ui-e2e-tests/explore-page.spec.ts
@@ -11,7 +11,11 @@ test('Display the list of toots in the explore page', async ({ page }) => {
 	]
 
 	for (const tootText of tootsTextsToCheck) {
-		await expect(page.locator('article').filter({ hasText: tootText })).toBeVisible()
+		if (tootText !== 'A very simple update: all good!') {
+			await expect(page.locator('article').filter({ hasText: tootText })).toBeVisible()
+		} else {
+			await expect(page.locator('article').filter({ hasText: tootText }).nth(1)).toBeVisible()
+		}
 	}
 })
 

--- a/ui-e2e-tests/invidivual-toot.spec.ts
+++ b/ui-e2e-tests/invidivual-toot.spec.ts
@@ -6,9 +6,9 @@ navigationVias.forEach((via) =>
 	test(`Navigation to and view of an individual toot via ${via}`, async ({ page }) => {
 		await page.goto('http://127.0.0.1:8788/explore')
 		if (via === 'time link') {
-			await page.locator('article').filter({ hasText: 'Ben, just Ben' }).locator('i.fa-globe + span').click()
+			await page.locator('article').filter({ hasText: 'Ben, just Ben' }).locator('i.fa-globe + span').nth(1).click()
 		} else {
-			await page.getByText('A very simple update: all good!').click()
+			await page.getByText('A very simple update: all good!').nth(1).click()
 		}
 		await expect(page.getByRole('button', { name: 'Back' })).toBeVisible()
 		await expect(page.getByRole('link', { name: 'Avatar of Ben, just Ben' })).toBeVisible()

--- a/ui-e2e-tests/seo.spec.ts
+++ b/ui-e2e-tests/seo.spec.ts
@@ -50,7 +50,7 @@ test.describe('Presence of appropriate SEO metadata across the application', () 
 		})
 
 		await page.goto('http://127.0.0.1:8788/explore')
-		await page.locator('article').filter({ hasText: 'Ben, just Ben' }).locator('i.fa-globe + span').click()
+		await page.locator('article').filter({ hasText: 'Ben, just Ben' }).locator('i.fa-globe + span').nth(1).click()
 		await checkPageSeoData(page, {
 			title: 'Ben, just Ben: A very simple update: all good… - Wildebeest',
 			description: 'A very simple update: all good!',


### PR DESCRIPTION
⚠️ This PR will disable some service features between the time the migration is performed and the time various Workers are deployed.

## Retention of Activity ID issued by Wildebeest

It will keep the ID of the Activity in order to implement a feature in the future that will allow access to URLs for Activities created by Wildebeest

## Correction of reblog data structure.

The current handling of reblogs broke the correspondence to the actual post object stored in the original_actor_id and properties of the objects table, so we changed the architecture to leave everything about reblogs to actor_reblogs. This will allow us to keep the data in the objects table consistent at the column level in the future.

## Change the method of retaining visibility data

Currently, one of the 'to' properties of the Note object in the case of posts, or one of the 'to' properties of the Announce Activity object in the case of reblogs, is stored in the 'target' column of outbox_objects.

For posts, the Note object is stored in the properties column of the objects table, but for reblogs, the Announce Activity object is not stored anywhere, making it impossible to infer visibility.

So in this PR, we add two columns, to and cc, to the outbox_objects table and assign the to and cc of the Note object for posts, and the to and cc of the Activity for reblogs, so that we do not lose visibility information.

Because both the actor_reblogs table and the outbox_objects table are being rebuilt, any process that uses these tables will result in an error from the time the migration is performed until the corrected code is reflected in the production environment.