### PR TITLE
Bump to v0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wildebeest",
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"type": "module",
 	"author": "Sven Sauleau <sven@cloudflare.com>",
 	"devDependencies": {


### PR DESCRIPTION
I want to do destructive migrations on tables that are referenced by other tables due to foreign key constraints, so I'm releasing v0.1.0 as the final version to use D1's alpha backend.

The next version is planned to be v1.0.0, which will require deploying D1 with the new beta backend and importing data before deploying. I'll be writing the migration guide soon.

In other words, v0.x.x is the version for people who want to use the alpha backend of D1, and v1.x.x is the version for people who want to use the beta backend.