### PR TITLE
Implement an API endpoint for editing post content

### DIFF
--- a/backend/src/activitypub/objects/index.ts
+++ b/backend/src/activitypub/objects/index.ts
@@ -340,7 +340,7 @@ async function cacheObject<T extends ApObject>(
 	}
 }
 
-export async function updateObject<T>(db: Database, properties: T, id: URL): Promise<void> {
+export async function updateObject<T extends ApObject>(db: Database, properties: T, id: URL): Promise<void> {
 	await query.updateObjectProperties(db, { properties: JSON.stringify(properties), id: id.toString() })
 }
 

--- a/backend/src/activitypub/objects/index.ts
+++ b/backend/src/activitypub/objects/index.ts
@@ -340,10 +340,6 @@ async function cacheObject<T extends ApObject>(
 	}
 }
 
-export async function updateObject<T extends ApObject>(db: Database, properties: T, id: URL): Promise<void> {
-	await query.updateObjectProperties(db, { properties: JSON.stringify(properties), id: id.toString() })
-}
-
 export async function updateObjectProperty(db: Database, obj: ApObject, key: string, value: string) {
 	await db
 		.prepare(`UPDATE objects SET properties=${db.qb.jsonSet('properties', key, '?1')} WHERE id=?2`)
@@ -523,6 +519,7 @@ export async function deleteObject<T extends ApObject>(db: Database, note: T) {
 		db.prepare('DELETE FROM actor_replies WHERE object_id=?1 OR in_reply_to_object_id=?1').bind(nodeId),
 		db.prepare('DELETE FROM idempotency_keys WHERE object_id=?').bind(nodeId),
 		db.prepare('DELETE FROM note_hashtags WHERE object_id=?').bind(nodeId),
+		db.prepare('DELETE FROM object_revisions WHERE object_id=?').bind(nodeId),
 		db.prepare('DELETE FROM objects WHERE id=?').bind(nodeId),
 	]
 

--- a/backend/src/database/d1/models.ts
+++ b/backend/src/database/d1/models.ts
@@ -211,3 +211,11 @@ export type Users = {
   cdate: string;
 };
 
+export type ObjectRevisions = {
+  id: number;
+  type: string;
+  objectId: string;
+  properties: string;
+  cdate: string;
+};
+

--- a/backend/src/database/d1/querier.ts
+++ b/backend/src/database/d1/querier.ts
@@ -284,6 +284,28 @@ export async function updateActorMastodonIdByMastodonId(
     .run();
 }
 
+const updateActorPropertiesQuery = `-- name: UpdateActorProperties :exec
+UPDATE actors
+SET
+  properties = ?
+WHERE
+  id = ?`;
+
+export type UpdateActorPropertiesParams = {
+  properties: string;
+  id: string;
+};
+
+export async function updateActorProperties(
+  d1: D1Database,
+  args: UpdateActorPropertiesParams
+): Promise<D1Result> {
+  return await d1
+    .prepare(updateActorPropertiesQuery)
+    .bind(args.properties, args.id)
+    .run();
+}
+
 const selectActorQuery = `-- name: SelectActor :one
 SELECT
   "id",
@@ -491,6 +513,53 @@ export async function insertIdSequence(
     .prepare(insertIdSequenceQuery)
     .bind(args.key)
     .first<InsertIdSequenceRow | null>();
+}
+
+const selectObjectRevisionsByObjectIDQuery = `-- name: SelectObjectRevisionsByObjectID :many
+SELECT
+  properties
+FROM
+  object_revisions
+WHERE
+  object_id = ?`;
+
+export type SelectObjectRevisionsByObjectIDParams = {
+  objectId: string;
+};
+
+export type SelectObjectRevisionsByObjectIDRow = {
+  properties: string;
+};
+
+export async function selectObjectRevisionsByObjectID(
+  d1: D1Database,
+  args: SelectObjectRevisionsByObjectIDParams
+): Promise<D1Result<SelectObjectRevisionsByObjectIDRow>> {
+  return await d1
+    .prepare(selectObjectRevisionsByObjectIDQuery)
+    .bind(args.objectId)
+    .all<SelectObjectRevisionsByObjectIDRow>();
+}
+
+const insertObjectRevisionQuery = `-- name: InsertObjectRevision :exec
+INSERT INTO
+  object_revisions ("object_id", "properties")
+VALUES
+  (?, ?)`;
+
+export type InsertObjectRevisionParams = {
+  objectId: string;
+  properties: string;
+};
+
+export async function insertObjectRevision(
+  d1: D1Database,
+  args: InsertObjectRevisionParams
+): Promise<D1Result> {
+  return await d1
+    .prepare(insertObjectRevisionQuery)
+    .bind(args.objectId, args.properties)
+    .run();
 }
 
 const insertRemoteObjectQuery = `-- name: InsertRemoteObject :exec

--- a/backend/src/database/sql/actors.sql
+++ b/backend/src/database/sql/actors.sql
@@ -26,6 +26,13 @@ SET
 WHERE
   mastodon_id = @current;
 
+-- name: UpdateActorProperties :exec
+UPDATE actors
+SET
+  properties = ?
+WHERE
+  id = ?;
+
 -- name: SelectActor :one
 SELECT
   "id",

--- a/backend/src/database/sql/object_revisions.sql
+++ b/backend/src/database/sql/object_revisions.sql
@@ -1,0 +1,13 @@
+-- name: SelectObjectRevisionsByObjectID :many
+SELECT
+  properties
+FROM
+  object_revisions
+WHERE
+  object_id = ?;
+
+-- name: InsertObjectRevision :exec
+INSERT INTO
+  object_revisions ("object_id", "properties")
+VALUES
+  (?, ?);

--- a/backend/src/mastodon/follow.ts
+++ b/backend/src/mastodon/follow.ts
@@ -88,26 +88,26 @@ export async function addFollowing(domain: string, db: Database, follower: Actor
 }
 
 // Accept the pending following request
-export async function acceptFollowing(db: Database, actor: Actor, target: Actor) {
+export async function acceptFollowing(db: Database, follower: Actor, followee: Actor) {
 	const query = `
 		UPDATE actor_following SET state=? WHERE actor_id=? AND target_actor_id=? AND state=?
 	`
 
 	const out = await db
 		.prepare(query)
-		.bind(STATE_ACCEPTED, actor.id.toString(), target.id.toString(), STATE_PENDING)
+		.bind(STATE_ACCEPTED, follower.id.toString(), followee.id.toString(), STATE_PENDING)
 		.run()
 	if (!out.success) {
 		throw new Error('SQL error: ' + out.error)
 	}
 }
 
-export async function removeFollowing(db: Database, actor: Actor, target: Actor) {
+export async function removeFollowing(db: Database, follower: Actor, followee: Actor) {
 	const query = `
 		DELETE FROM actor_following WHERE actor_id=? AND target_actor_id=?
 	`
 
-	const out = await db.prepare(query).bind(actor.id.toString(), target.id.toString()).run()
+	const out = await db.prepare(query).bind(follower.id.toString(), followee.id.toString()).run()
 	if (!out.success) {
 		throw new Error('SQL error: ' + out.error)
 	}

--- a/backend/src/mastodon/status.ts
+++ b/backend/src/mastodon/status.ts
@@ -27,6 +27,9 @@ import type { MediaAttachment } from 'wildebeest/backend/src/types/media'
 import { actorToAcct, actorToHandle, handleToAcct, parseHandle } from 'wildebeest/backend/src/utils/handle'
 import { queryAcct } from 'wildebeest/backend/src/webfinger'
 
+export const MAX_STATUS_LENGTH = 500
+export const MAX_MEDIA_ATTACHMENTS = 4
+
 export async function getMentions(input: string, instanceDomain: string, db: Database): Promise<Set<Actor>> {
 	const actors = new Set<Actor>()
 	const mentions = new Set<string>()

--- a/backend/src/types/status.ts
+++ b/backend/src/types/status.ts
@@ -127,3 +127,16 @@ export type Context = {
 	ancestors: MastodonStatus[]
 	descendants: MastodonStatus[]
 }
+
+export type MastodonStatusEdit = {
+	content: string
+	spoiler_text: string
+	sensitive: boolean
+	created_at: string
+	account: MastodonAccount
+	poll?: {
+		options: { title: string }[]
+	}
+	media_attachments: MediaAttachment[]
+	emojis: CustomEmoji[]
+}

--- a/backend/test/activitypub/handle.spec.ts
+++ b/backend/test/activitypub/handle.spec.ts
@@ -12,15 +12,18 @@ import {
 	UpdateActivity,
 } from 'wildebeest/backend/src/activitypub/activities'
 import * as activityHandler from 'wildebeest/backend/src/activitypub/activities/handle'
+import { Actor } from 'wildebeest/backend/src/activitypub/actors'
 import {
 	ApObject,
 	getAndCacheObject,
 	getApId,
+	mastodonIdSymbol,
 	originalObjectIdSymbol,
 } from 'wildebeest/backend/src/activitypub/objects'
 import { getObjectById } from 'wildebeest/backend/src/activitypub/objects/'
 import { Note } from 'wildebeest/backend/src/activitypub/objects/note'
 import { acceptFollowing, addFollowing } from 'wildebeest/backend/src/mastodon/follow'
+import { MastodonStatusEdit } from 'wildebeest/backend/src/types'
 import { actorToHandle } from 'wildebeest/backend/src/utils/handle'
 import type { JWK } from 'wildebeest/backend/src/webpush/jwk'
 import {
@@ -29,8 +32,9 @@ import {
 	createPublicStatus,
 	createUnlistedStatus,
 } from 'wildebeest/backend/test/shared.utils'
+import * as statuses_history from 'wildebeest/functions/api/v1/statuses/[id]/history'
 
-import { createActivityId, createTestUser, makeDB } from '../utils'
+import { assertStatus, createActivityId, createTestUser, makeDB } from '../utils'
 
 const adminEmail = 'admin@example.com'
 const domain = 'cloudflare.com'
@@ -562,22 +566,84 @@ describe('ActivityPub', () => {
 				})
 			})
 
-			test('Object is updated', async () => {
+			test('Object(Note) is updated', async () => {
 				const db = await makeDB()
 				const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
-				const object = {
+
+				const note: Note = {
 					id: 'https://example.com/note2',
 					type: 'Note',
-					content: 'test note',
+					attributedTo: actor.id,
+					attachment: [],
+					content: 'test note<script>alert("evil")</script>',
+					to: [PUBLIC_GROUP],
+					cc: [],
+					sensitive: false,
 				}
 
-				const obj = await getAndCacheObject(domain, db, object, actor)
-				assert.notEqual(obj, null, 'could not create object')
+				const { object: obj } = await getAndCacheObject(domain, db, note, actor)
+				assert.ok(obj, 'could not create object')
 
-				const newObject: ApObject = {
-					id: getApId('https://example.com/note2'),
-					type: 'Note',
-					content: 'new test note',
+				const now = new Date('2023-08-16T16:22:14.190Z').toISOString()
+				const newNote: Note = {
+					...note,
+					content: 'new test note<script>alert("evil")</script>',
+					updated: now,
+				}
+
+				const activity: UpdateActivity = {
+					'@context': 'https://www.w3.org/ns/activitystreams',
+					id: createActivityId(domain),
+					type: 'Update',
+					actor: actor.id,
+					object: newNote,
+				}
+
+				await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
+
+				const updatedObject = await db
+					.prepare('SELECT id, properties FROM objects WHERE original_object_id=?')
+					.bind(note.id.toString())
+					.first<{ id: string; properties: string }>()
+				assert(updatedObject)
+				assert.equal(JSON.parse(updatedObject.properties).content, newNote.content)
+
+				{
+					const res = await statuses_history.onRequestGet({
+						request: new Request('https://' + domain),
+						env: { DATABASE: db },
+						params: { id: obj[mastodonIdSymbol] },
+						data: { connectedActor: actor },
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					} as any)
+					await assertStatus(res, 200)
+
+					const data = await res.json<MastodonStatusEdit[]>()
+					assert.equal(data.length, 2)
+					assert.equal(data[0].content, 'test note<p>alert("evil")</p>')
+					assert.equal(data[1].content, 'new test note<p>alert("evil")</p>')
+					assert.notEqual(data[0].created_at, data[1].created_at)
+				}
+
+				{
+					// duplicate update
+					await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
+					const res = await db
+						.prepare('SELECT count(*) as count FROM object_revisions WHERE object_id=?')
+						.bind(updatedObject.id)
+						.first<{ count: number }>()
+					assert.ok(res)
+					assert.equal(res.count, 1)
+				}
+			})
+
+			test('Object(Actor) is updated', async () => {
+				const db = await makeDB()
+				const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
+
+				const newObject: Actor = {
+					...actor,
+					summary: 'new summary',
 				}
 
 				const activity: UpdateActivity = {
@@ -591,10 +657,10 @@ describe('ActivityPub', () => {
 				await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
 
 				const updatedObject = await db
-					.prepare('SELECT * FROM objects WHERE original_object_id=?')
-					.bind(object.id)
+					.prepare('SELECT properties FROM actors WHERE id=?')
+					.bind(actor.id.toString())
 					.first<{ properties: string }>()
-				assert(updatedObject)
+				assert.ok(updatedObject)
 				assert.equal(JSON.parse(updatedObject.properties).content, newObject.content)
 			})
 		})

--- a/backend/test/mastodon/accounts.spec.ts
+++ b/backend/test/mastodon/accounts.spec.ts
@@ -527,17 +527,17 @@ describe('Mastodon APIs', () => {
 			assert.equal(data[0].favourites_count, 0)
 			assert.equal(data[0].reblogs_count, 0)
 			assert.equal(data[0].uri, 'https://example.com/activity')
-			assert.equal(data[0].reblog.content, 'my second status')
+			assert.equal(data[0].reblog.content, '<p>my second status</p>')
 
 			assert(!isUUID(data[1].id) && !isNaN(Number(data[1].id)), data[1].id)
-			assert.equal(data[1].content, 'my second status')
+			assert.equal(data[1].content, '<p>my second status</p>')
 			assert.equal(data[1].account.acct, 'sven')
 			assert.equal(data[1].favourites_count, 0)
 			assert.equal(data[1].reblogs_count, 1)
 			assert.equal(new URL(data[1].url).pathname, '/@sven/' + data[1].id)
 
 			assert(!isUUID(data[2].id) && !isNaN(Number(data[2].id)), data[2].id)
-			assert.equal(data[2].content, 'my first status')
+			assert.equal(data[2].content, '<p>my first status</p>')
 			assert.equal(data[2].favourites_count, 1)
 			assert.equal(data[2].reblogs_count, 0)
 		})
@@ -547,7 +547,7 @@ describe('Mastodon APIs', () => {
 			const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 			const note = await createPublicStatus(domain, db, actor, 'a post')
 			await sleep(10)
-			await createReply(domain, db, actor, note, 'a reply')
+			await createReply(domain, db, actor, note, '@sven@cloudflare.com a reply')
 
 			const res = await accounts_statuses.onRequestGet({
 				request: new Request(`https://${domain}?exclude_replies=true`),

--- a/backend/test/mastodon/notifications.spec.ts
+++ b/backend/test/mastodon/notifications.spec.ts
@@ -87,7 +87,7 @@ describe('Mastodon APIs', () => {
 			assert.equal(data.id, '1')
 			assert.equal(data.type, 'favourite')
 			assert.equal(data.account.acct, 'from')
-			assert.equal(data.status.content, 'my first status')
+			assert.equal(data.status.content, '<p>my first status</p>')
 		})
 
 		test('get single follow notification', async () => {

--- a/backend/test/mastodon/timelines.spec.ts
+++ b/backend/test/mastodon/timelines.spec.ts
@@ -55,11 +55,11 @@ describe('Mastodon APIs', () => {
 			assert(data[0].id)
 			assert.equal(data[0].content, '')
 			assert.equal(data[0].account.username, 'sven')
-			assert.equal(data[0].reblog?.content, 'first status from actor2')
+			assert.equal(data[0].reblog?.content, '<p>first status from actor2</p>')
 			assert.equal(data[0].reblog?.account.username, 'sven2')
-			assert.equal(data[1].content, 'second status from actor2')
+			assert.equal(data[1].content, '<p>second status from actor2</p>')
 			assert.equal(data[1].account.username, 'sven2')
-			assert.equal(data[2].content, 'first status from actor2')
+			assert.equal(data[2].content, '<p>first status from actor2</p>')
 			assert.equal(data[2].account.username, 'sven2')
 			assert.equal(data[2].favourites_count, 1)
 			assert.equal(data[2].reblogs_count, 1)
@@ -100,7 +100,7 @@ describe('Mastodon APIs', () => {
 			// Actor should only see posts from actor2 in the timeline
 			const data = await timelines.getHomeTimeline(domain, db, actor)
 			assert.equal(data.length, 1)
-			assert.equal(data[0].content, 'test post')
+			assert.equal(data[0].content, '<p>test post</p>')
 		})
 
 		test("public doesn't show private Notes", async () => {
@@ -127,7 +127,7 @@ describe('Mastodon APIs', () => {
 			const data = await timelines.getHomeTimeline(domain, db, connectedActor)
 			assert.equal(data.length, 1)
 			assert(data[0].id)
-			assert.equal(data[0].content, 'status from myself')
+			assert.equal(data[0].content, '<p>status from myself</p>')
 			assert.equal(data[0].account.username, 'sven')
 		})
 
@@ -184,13 +184,13 @@ describe('Mastodon APIs', () => {
 			assert(data[0].id)
 			assert.equal(data[0].content, '')
 			assert.equal(data[0].account.username, 'sven')
-			assert.equal(data[0].reblog.content, 'status from actor')
+			assert.equal(data[0].reblog.content, '<p>status from actor</p>')
 			assert.equal(data[0].reblog.account.username, 'sven')
 
-			assert.equal(data[1].content, 'status from actor2')
+			assert.equal(data[1].content, '<p>status from actor2</p>')
 			assert.equal(data[1].account.username, 'sven2')
 
-			assert.equal(data[2].content, 'status from actor')
+			assert.equal(data[2].content, '<p>status from actor</p>')
 			assert.equal(data[2].account.username, 'sven')
 			assert.equal(data[2].favourites_count, 1)
 			assert.equal(data[2].reblogs_count, 1)
@@ -248,9 +248,9 @@ describe('Mastodon APIs', () => {
 			await assertStatus(res, 200)
 
 			const data = await res.json<any>()
-			assert.equal(data[0].content, 'note3')
-			assert.equal(data[1].content, 'note1')
-			assert.equal(data[2].content, 'note2')
+			assert.equal(data[0].content, '<p>note3</p>')
+			assert.equal(data[1].content, '<p>note1</p>')
+			assert.equal(data[2].content, '<p>note2</p>')
 		})
 
 		test('home timelines do not hides and counts public replies', async () => {
@@ -261,23 +261,26 @@ describe('Mastodon APIs', () => {
 
 			await sleep(10)
 
-			await createReply(domain, db, actor, note, 'a reply')
+			await createReply(domain, db, actor, note, '@sven@cloudflare.com a reply')
 
 			const connectedActor: any = actor
 
 			{
 				const data = await timelines.getHomeTimeline(domain, db, connectedActor)
 				assert.equal(data.length, 2)
-				assert.equal(data[0].content, 'a reply')
+				assert.equal(
+					data[0].content,
+					'<p><span class="h-card"><a href="https://cloudflare.com/@sven" class="u-url mention">@<span>sven</span></a></span> a reply</p>'
+				)
 				assert.equal(data[0].replies_count, 0)
-				assert.equal(data[1].content, 'a post')
+				assert.equal(data[1].content, '<p>a post</p>')
 				assert.equal(data[1].replies_count, 1)
 			}
 
 			{
 				const data = await timelines.getPublicTimeline(domain, db, timelines.LocalPreference.NotSet, false, 20)
 				assert.equal(data.length, 1)
-				assert.equal(data[0].content, 'a post')
+				assert.equal(data[0].content, '<p>a post</p>')
 				assert.equal(data[0].replies_count, 1)
 			}
 		})
@@ -390,8 +393,8 @@ describe('Mastodon APIs', () => {
 					'test'
 				)
 				assert.equal(data.length, 2)
-				assert.equal(data[0].content, 'test 2')
-				assert.equal(data[1].content, 'test 1')
+				assert.equal(data[0].content, '<p>test 2</p>')
+				assert.equal(data[1].content, '<p>test 1</p>')
 			}
 
 			{
@@ -406,7 +409,7 @@ describe('Mastodon APIs', () => {
 					'a'
 				)
 				assert.equal(data.length, 1)
-				assert.equal(data[0].content, 'test 1')
+				assert.equal(data[0].content, '<p>test 1</p>')
 			}
 		})
 	})

--- a/frontend/mock-db/init.ts
+++ b/frontend/mock-db/init.ts
@@ -24,7 +24,8 @@ export async function init(domain: string, db: Database) {
 			actor,
 			status.content,
 			status.media_attachments as unknown as (Document | Image)[],
-			{ spoiler_text: status.spoiler_text }
+			{ spoiler_text: status.spoiler_text },
+			true
 		)
 		loadedStatuses.push({ status, note })
 	}

--- a/frontend/src/dummyData/statuses.ts
+++ b/frontend/src/dummyData/statuses.ts
@@ -63,8 +63,8 @@ export const statuses: MastodonStatus[] = mastodonRawStatuses.map((rawStatus) =>
 }))
 
 export const replies: MastodonStatus[] = [
-	generateDummyStatus({ content: '<p>Yes we did! 🎉</p>', account: zak, inReplyTo: statuses[1].id }),
-	generateDummyStatus({ content: '<p> Yes you guys did it! </p>', account: penny, inReplyTo: statuses[1].id }),
+	generateDummyStatus({ content: '@george Yes we did! 🎉', account: zak, inReplyTo: statuses[1].id }),
+	generateDummyStatus({ content: '@george Yes you guys did it!', account: penny, inReplyTo: statuses[1].id }),
 ]
 
 export const reblogs: MastodonStatus[] = [generateDummyStatus({ account: george, reblog: statuses[2] })]

--- a/functions/api/v1/statuses.ts
+++ b/functions/api/v1/statuses.ts
@@ -22,7 +22,12 @@ import { getHashtags, insertHashtags } from 'wildebeest/backend/src/mastodon/has
 import * as idempotency from 'wildebeest/backend/src/mastodon/idempotency'
 import { enrichStatus } from 'wildebeest/backend/src/mastodon/microformats'
 import { insertReply } from 'wildebeest/backend/src/mastodon/reply'
-import { getMentions, toMastodonStatusFromObject } from 'wildebeest/backend/src/mastodon/status'
+import {
+	getMentions,
+	MAX_MEDIA_ATTACHMENTS,
+	MAX_STATUS_LENGTH,
+	toMastodonStatusFromObject,
+} from 'wildebeest/backend/src/mastodon/status'
 import * as timeline from 'wildebeest/backend/src/mastodon/timeline'
 import { ContextData, DeliverMessageBody, Env, Queue, Visibility } from 'wildebeest/backend/src/types'
 import { cors, myz, readBody } from 'wildebeest/backend/src/utils'
@@ -33,9 +38,6 @@ const headers = {
 	...cors(),
 	'content-type': 'application/json; charset=utf-8',
 }
-
-const MAX_STATUS_LENGTH = 500
-const MAX_MEDIA_ATTACHMENTS = 4
 
 const schema = z.object({
 	// TODO: check server settings for max length

--- a/functions/api/v1/statuses/[id].ts
+++ b/functions/api/v1/statuses/[id].ts
@@ -88,6 +88,11 @@ export const onRequestPut: PagesFunction<Env, 'id', ContextData> = async ({
 			result.data
 		)
 	}
+	const { issues } = result.error
+	if (issues.length > 0) {
+		const [issue] = issues
+		return errors.validationError(`Validation failed: ${issue.path[0]} ${issue.code}`)
+	}
 	return new Response('', { status: 400 })
 }
 

--- a/functions/api/v1/statuses/[id].ts
+++ b/functions/api/v1/statuses/[id].ts
@@ -1,18 +1,40 @@
 // https://docs.joinmastodon.org/methods/statuses/#get
 
 import { createDeleteActivity } from 'wildebeest/backend/src/activitypub/activities/delete'
+import { createUpdateActivity } from 'wildebeest/backend/src/activitypub/activities/update'
 import type { Person } from 'wildebeest/backend/src/activitypub/actors'
 import { deliverFollowers } from 'wildebeest/backend/src/activitypub/deliver'
-import { deleteObject, getObjectByMastodonId } from 'wildebeest/backend/src/activitypub/objects'
+import {
+	deleteObject,
+	getApId,
+	getObjectByMastodonId,
+	originalActorIdSymbol,
+	updateObject,
+} from 'wildebeest/backend/src/activitypub/objects'
+import { Image, isImage } from 'wildebeest/backend/src/activitypub/objects/image'
+import { newMention } from 'wildebeest/backend/src/activitypub/objects/mention'
 import { Note } from 'wildebeest/backend/src/activitypub/objects/note'
 import { Cache, cacheFromEnv } from 'wildebeest/backend/src/cache'
 import { type Database, getDatabase } from 'wildebeest/backend/src/database'
 import * as errors from 'wildebeest/backend/src/errors'
-import { getMastodonStatusById, toMastodonStatusFromObject } from 'wildebeest/backend/src/mastodon/status'
+import { enrichStatus } from 'wildebeest/backend/src/mastodon/microformats'
+import {
+	getMastodonStatusById,
+	getMentions,
+	MAX_MEDIA_ATTACHMENTS,
+	MAX_STATUS_LENGTH,
+	toMastodonStatusFromObject,
+} from 'wildebeest/backend/src/mastodon/status'
 import * as timeline from 'wildebeest/backend/src/mastodon/timeline'
 import type { ContextData, DeliverMessageBody, Env, MastodonId, Queue } from 'wildebeest/backend/src/types'
+import { myz, readBody } from 'wildebeest/backend/src/utils'
 import { cors } from 'wildebeest/backend/src/utils/cors'
-import { actorToAcct } from 'wildebeest/backend/src/utils/handle'
+import { z } from 'zod'
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
 
 export const onRequestGet: PagesFunction<Env, 'id', ContextData> = async ({ params: { id }, env, request, data }) => {
 	if (typeof id !== 'string') {
@@ -20,6 +42,53 @@ export const onRequestGet: PagesFunction<Env, 'id', ContextData> = async ({ para
 	}
 	const domain = new URL(request.url).hostname
 	return handleRequestGet(await getDatabase(env), id, domain, data.connectedActor)
+}
+
+const schema = z.object({
+	status: z.string().max(MAX_STATUS_LENGTH).optional(),
+	spoiler_text: z.string().optional(),
+	sensitive: myz.logical().optional(),
+	media_ids: z.array(z.string()).max(MAX_MEDIA_ATTACHMENTS).optional(),
+	// TODO: support polls, language
+})
+
+type PutParameters = z.infer<typeof schema>
+
+type PutDependencies = {
+	domain: string
+	db: Database
+	connectedActor: Person
+	userKEK: string
+	queue: Queue<DeliverMessageBody>
+	cache: Cache
+}
+
+export const onRequestPut: PagesFunction<Env, 'id', ContextData> = async ({
+	params: { id },
+	env,
+	request,
+	data: { connectedActor },
+}) => {
+	if (typeof id !== 'string') {
+		return errors.statusNotFound(String(id))
+	}
+	const result = await readBody(request, schema)
+	if (result.success) {
+		const url = new URL(request.url)
+		return handleRequestPut(
+			{
+				domain: url.hostname,
+				db: await getDatabase(env),
+				connectedActor,
+				userKEK: env.userKEK,
+				queue: env.QUEUE,
+				cache: cacheFromEnv(env),
+			},
+			id,
+			result.data
+		)
+	}
+	return new Response('', { status: 400 })
 }
 
 export const onRequestDelete: PagesFunction<Env, 'id', ContextData> = async ({
@@ -63,10 +132,82 @@ export async function handleRequestGet(
 	}
 	*/
 
-	const headers = {
-		...cors(),
-		'content-type': 'application/json; charset=utf-8',
+	return new Response(JSON.stringify(status), { headers })
+}
+
+export async function handleRequestPut(
+	{ domain, db, connectedActor, userKEK, queue, cache }: PutDependencies,
+	id: MastodonId,
+	params: PutParameters
+): Promise<Response> {
+	const obj = await getObjectByMastodonId<Note>(domain, db, id)
+	if (obj === null) {
+		return errors.statusNotFound(id)
 	}
+
+	if (obj[originalActorIdSymbol] !== connectedActor.id.toString()) {
+		return errors.statusNotFound(id)
+	}
+
+	let updated = false
+	const updatedObj = obj
+
+	if (params.media_ids && params.media_ids.length > 0) {
+		const mediaAttachments: Image[] = []
+
+		for (const id of [...params.media_ids]) {
+			const document = await getObjectByMastodonId(domain, db, id)
+			if (document === null) {
+				console.warn('object attachment not found: ' + id)
+				continue
+			}
+			if (!isImage(document)) {
+				console.warn('object is not a image: ' + id)
+				continue
+			}
+			mediaAttachments.push(document)
+		}
+
+		updated = true
+		updatedObj.attachment = mediaAttachments
+	}
+
+	if (params.status) {
+		updated = true
+		updatedObj.source = { content: params.status, mediaType: 'text/markdown' }
+
+		const mentions = await getMentions(params.status, domain, db)
+		updatedObj.tag = mentions.size > 0 ? [...mentions].map((actor) => newMention(actor, domain)) : undefined
+
+		updatedObj.content = enrichStatus(params.status, mentions)
+	}
+
+	if (params.spoiler_text) {
+		updated = true
+		updatedObj.spoiler_text = params.spoiler_text
+	}
+
+	if (params.sensitive !== undefined) {
+		updated = true
+		updatedObj.sensitive = params.sensitive
+	}
+
+	if (updated) {
+		updatedObj.updated = new Date().toISOString()
+
+		await updateObject(db, updatedObj, getApId(obj.id))
+
+		const activity = await createUpdateActivity(db, domain, connectedActor, updatedObj)
+		await deliverFollowers(db, userKEK, connectedActor, activity, queue)
+
+		await timeline.pregenerateTimelines(domain, db, cache, connectedActor)
+	}
+
+	const status = await toMastodonStatusFromObject(db, updatedObj, domain)
+	if (status === null) {
+		return errors.statusNotFound(id)
+	}
+
 	return new Response(JSON.stringify(status), { headers })
 }
 
@@ -84,11 +225,7 @@ export async function handleRequestDelete(
 		return errors.statusNotFound(id)
 	}
 
-	const status = await toMastodonStatusFromObject(db, obj, domain)
-	if (status === null) {
-		return errors.statusNotFound(id)
-	}
-	if (status.account.acct !== actorToAcct(connectedActor, domain)) {
+	if (obj[originalActorIdSymbol] !== connectedActor.id.toString()) {
 		return errors.statusNotFound(id)
 	}
 
@@ -100,9 +237,10 @@ export async function handleRequestDelete(
 
 	await timeline.pregenerateTimelines(domain, db, cache, connectedActor)
 
-	const headers = {
-		...cors(),
-		'content-type': 'application/json; charset=utf-8',
+	const status = await toMastodonStatusFromObject(db, obj, domain)
+	if (status === null) {
+		return errors.statusNotFound(id)
 	}
+
 	return new Response(JSON.stringify(status), { headers })
 }

--- a/functions/api/v1/statuses/[id]/history.ts
+++ b/functions/api/v1/statuses/[id]/history.ts
@@ -1,0 +1,63 @@
+// https://docs.joinmastodon.org/methods/statuses/#history
+
+import { Actor, getActorById } from 'wildebeest/backend/src/activitypub/actors'
+import { getObjectByMastodonId, originalActorIdSymbol } from 'wildebeest/backend/src/activitypub/objects'
+import { isNote, Note } from 'wildebeest/backend/src/activitypub/objects/note'
+import { Database, getDatabase } from 'wildebeest/backend/src/database'
+import { recordNotFound, statusNotFound } from 'wildebeest/backend/src/errors'
+import { getStatusRevisions, isVisible } from 'wildebeest/backend/src/mastodon/status'
+import { ContextData, Env, MastodonId, MastodonStatusEdit } from 'wildebeest/backend/src/types'
+import { cors, makeJsonResponse, MastodonApiResponse } from 'wildebeest/backend/src/utils'
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+type Dependencies = {
+	domain: string
+	db: Database
+	connectedActor: Actor
+}
+
+export const onRequestGet: PagesFunction<Env, 'id', ContextData> = async ({
+	request,
+	env,
+	params: { id },
+	data: { connectedActor },
+}) => {
+	if (typeof id !== 'string') {
+		return statusNotFound(String(id))
+	}
+	const url = new URL(request.url)
+	return handleRequestGet(
+		{
+			domain: url.hostname,
+			db: await getDatabase(env),
+			connectedActor,
+		},
+		id
+	)
+}
+
+async function handleRequestGet(
+	{ domain, db, connectedActor }: Dependencies,
+	id: MastodonId
+): Promise<MastodonApiResponse<MastodonStatusEdit[]>> {
+	const obj = await getObjectByMastodonId<Note>(domain, db, id)
+	if (obj === null) {
+		return recordNotFound(id)
+	}
+	if (!isNote(obj)) {
+		return statusNotFound(id)
+	}
+	const author = await getActorById(db, obj[originalActorIdSymbol])
+	if (author === null) {
+		return recordNotFound(id)
+	}
+	const visible = await isVisible(db, author, connectedActor, obj)
+	if (!visible) {
+		return statusNotFound(id)
+	}
+	return makeJsonResponse(await getStatusRevisions(domain, db, author, obj), { headers })
+}

--- a/migrations/0023_add_object_revisions.sql
+++ b/migrations/0023_add_object_revisions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE
+  object_revisions (
+    "id" INTEGER NOT NULL PRIMARY KEY,
+    "type" TEXT NOT NULL GENERATED ALWAYS AS (JSON_EXTRACT("properties", '$.type')) STORED,
+    "object_id" TEXT NOT NULL,
+    "properties" TEXT NOT NULL,
+    "cdate" DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+    CONSTRAINT "object_revisions_object_id_fkey" FOREIGN KEY ("object_id") REFERENCES "objects" ("id") ON DELETE CASCADE
+  );
+
+CREATE INDEX "object_revisions_object_id" ON "object_revisions" ("object_id");

--- a/schema.sql
+++ b/schema.sql
@@ -298,3 +298,15 @@ CREATE TABLE
   );
 
 CREATE INDEX "users_email" ON "users" ("email");
+
+CREATE TABLE
+  object_revisions (
+    "id" INTEGER NOT NULL PRIMARY KEY,
+    "type" TEXT NOT NULL GENERATED ALWAYS AS (JSON_EXTRACT("propertis", '$.type')) STORED,
+    "object_id" TEXT NOT NULL,
+    "properties" TEXT NOT NULL,
+    "cdate" DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+    CONSTRAINT "object_revisions_object_id_fkey" FOREIGN KEY ("object_id") REFERENCES "objects" ("id") ON DELETE CASCADE
+  );
+
+CREATE INDEX "object_revisions_object_id" ON "object_revisions" ("object_id");


### PR DESCRIPTION
- [x] `PUT /api/v1/statuses/:id HTTP/1.1` https://docs.joinmastodon.org/methods/statuses/#edit
  - supported params: status, spoiler_text, sensitive, media_ids[]
- [x] `GET /api/v1/statuses/:id/history HTTP/1.1` https://docs.joinmastodon.org/methods/statuses/#history
