### PR TITLE
Project reply interaction counts

### DIFF
--- a/migrations/0036_backfill_in_reply_to_id.sql
+++ b/migrations/0036_backfill_in_reply_to_id.sql
@@ -1,0 +1,54 @@
+-- Backfill reply columns before read paths depend on objects.in_reply_to_id.
+-- This migration must be applied before deploying Workers that read objects.in_reply_to_id.
+UPDATE objects SET in_reply_to_id = (
+  SELECT ar.in_reply_to_object_id
+  FROM actor_replies ar
+  INNER JOIN objects AS reply ON reply.id = ar.object_id
+  INNER JOIN objects AS parent ON parent.id = ar.in_reply_to_object_id
+  WHERE ar.object_id = objects.id
+    AND (
+      ar.in_reply_to_object_id = reply.reply_to_object_id
+      OR parent.original_object_id = reply.reply_to_object_id
+    )
+  ORDER BY ar.id
+  LIMIT 1
+)
+WHERE in_reply_to_id IS NULL
+  AND EXISTS (
+    SELECT 1 FROM actor_replies ar
+    INNER JOIN objects AS reply ON reply.id = ar.object_id
+    INNER JOIN objects AS parent ON parent.id = ar.in_reply_to_object_id
+    WHERE ar.object_id = objects.id
+      AND (
+        ar.in_reply_to_object_id = reply.reply_to_object_id
+        OR parent.original_object_id = reply.reply_to_object_id
+      )
+  );
+
+UPDATE objects SET in_reply_to_id = (
+  SELECT parent.id
+  FROM objects AS parent
+  WHERE parent.id = objects.reply_to_object_id
+     OR parent.original_object_id = objects.reply_to_object_id
+  ORDER BY parent.id
+  LIMIT 1
+)
+WHERE in_reply_to_id IS NULL
+  AND reply_to_object_id IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM objects AS parent
+    WHERE parent.id = objects.reply_to_object_id
+       OR parent.original_object_id = objects.reply_to_object_id
+  );
+
+UPDATE objects SET in_reply_to_account_id = (
+  SELECT original_actor_id FROM objects AS parent
+  WHERE parent.id = objects.in_reply_to_id
+)
+WHERE in_reply_to_id IS NOT NULL
+  AND in_reply_to_account_id IS NULL;
+
+UPDATE objects SET replies_count = (
+  SELECT COUNT(*) FROM objects AS replies
+  WHERE replies.in_reply_to_id = objects.id
+);

--- a/migrations/0036_backfill_in_reply_to_id.sql
+++ b/migrations/0036_backfill_in_reply_to_id.sql
@@ -10,7 +10,9 @@ UPDATE objects SET in_reply_to_id = (
       ar.in_reply_to_object_id = reply.reply_to_object_id
       OR parent.original_object_id = reply.reply_to_object_id
     )
-  ORDER BY ar.id
+  ORDER BY
+    CASE WHEN ar.in_reply_to_object_id = reply.reply_to_object_id THEN 0 ELSE 1 END,
+    ar.id
   LIMIT 1
 )
 WHERE in_reply_to_id IS NULL
@@ -25,13 +27,21 @@ WHERE in_reply_to_id IS NULL
       )
   );
 
-UPDATE objects SET in_reply_to_id = (
-  SELECT parent.id
-  FROM objects AS parent
-  WHERE parent.id = objects.reply_to_object_id
-     OR parent.original_object_id = objects.reply_to_object_id
-  ORDER BY parent.id
-  LIMIT 1
+UPDATE objects SET in_reply_to_id = COALESCE(
+  (
+    SELECT parent.id
+    FROM objects AS parent
+    WHERE parent.id = objects.reply_to_object_id
+    ORDER BY parent.id
+    LIMIT 1
+  ),
+  (
+    SELECT parent.id
+    FROM objects AS parent
+    WHERE parent.original_object_id = objects.reply_to_object_id
+    ORDER BY parent.id
+    LIMIT 1
+  )
 )
 WHERE in_reply_to_id IS NULL
   AND reply_to_object_id IS NOT NULL
@@ -47,6 +57,9 @@ UPDATE objects SET in_reply_to_account_id = (
 )
 WHERE in_reply_to_id IS NOT NULL
   AND in_reply_to_account_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS "objects_in_reply_to_id" ON "objects" ("in_reply_to_id")
+  WHERE "in_reply_to_id" IS NOT NULL;
 
 UPDATE objects SET replies_count = (
   SELECT COUNT(*) FROM objects AS replies

--- a/migrations/0037_backfill_reblogs_count_and_add_in_reply_to_id_index.sql
+++ b/migrations/0037_backfill_reblogs_count_and_add_in_reply_to_id_index.sql
@@ -1,0 +1,7 @@
+UPDATE objects SET reblogs_count = (
+  SELECT COUNT(*) FROM actor_reblogs
+  WHERE actor_reblogs.object_id = objects.id
+);
+
+CREATE INDEX IF NOT EXISTS "objects_in_reply_to_id" ON "objects" ("in_reply_to_id")
+  WHERE "in_reply_to_id" IS NOT NULL;

--- a/migrations/0037_backfill_reblogs_count_and_add_in_reply_to_id_index.sql
+++ b/migrations/0037_backfill_reblogs_count_and_add_in_reply_to_id_index.sql
@@ -2,6 +2,3 @@ UPDATE objects SET reblogs_count = (
   SELECT COUNT(*) FROM actor_reblogs
   WHERE actor_reblogs.object_id = objects.id
 );
-
-CREATE INDEX IF NOT EXISTS "objects_in_reply_to_id" ON "objects" ("in_reply_to_id")
-  WHERE "in_reply_to_id" IS NOT NULL;

--- a/migrations/0038_add_actor_replies_unique_index.sql
+++ b/migrations/0038_add_actor_replies_unique_index.sql
@@ -1,0 +1,32 @@
+DELETE FROM actor_replies
+WHERE id NOT IN (
+  SELECT COALESCE(
+    (
+      SELECT canonical.id
+      FROM actor_replies AS canonical
+      INNER JOIN objects AS reply ON reply.id = canonical.object_id
+      WHERE canonical.object_id = actor_replies.object_id
+        AND canonical.in_reply_to_object_id = reply.in_reply_to_id
+      ORDER BY canonical.id
+      LIMIT 1
+    ),
+    (
+      SELECT canonical.id
+      FROM actor_replies AS canonical
+      INNER JOIN objects AS reply ON reply.id = canonical.object_id
+      LEFT JOIN objects AS parent ON parent.id = canonical.in_reply_to_object_id
+      WHERE canonical.object_id = actor_replies.object_id
+        AND (
+          canonical.in_reply_to_object_id = json_extract(reply.properties, '$.inReplyTo')
+          OR parent.original_object_id = json_extract(reply.properties, '$.inReplyTo')
+      )
+      ORDER BY canonical.id
+      LIMIT 1
+    ),
+    MIN(grouped.id)
+  )
+  FROM actor_replies AS grouped
+  WHERE grouped.object_id = actor_replies.object_id
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "actor_replies_unique_object_id" ON "actor_replies" ("object_id");

--- a/migrations/0038_add_actor_replies_unique_index.sql
+++ b/migrations/0038_add_actor_replies_unique_index.sql
@@ -20,7 +20,12 @@ WHERE id NOT IN (
           canonical.in_reply_to_object_id = json_extract(reply.properties, '$.inReplyTo')
           OR parent.original_object_id = json_extract(reply.properties, '$.inReplyTo')
       )
-      ORDER BY canonical.id
+      ORDER BY
+        CASE
+          WHEN canonical.in_reply_to_object_id = json_extract(reply.properties, '$.inReplyTo') THEN 0
+          ELSE 1
+        END,
+        canonical.id
       LIMIT 1
     ),
     MIN(grouped.id)

--- a/migrations/0039_add_relationship_visibility_indexes.sql
+++ b/migrations/0039_add_relationship_visibility_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS "blocks_target_account_id_account_id" ON "blocks" ("target_account_id", "account_id");
+CREATE INDEX IF NOT EXISTS "outbox_objects_object_id_published_date" ON "outbox_objects" ("object_id", "published_date");

--- a/packages/backend/src/activitypub/objects/index.ts
+++ b/packages/backend/src/activitypub/objects/index.ts
@@ -4,7 +4,12 @@ import { addPeer } from '@wildebeest/backend/activitypub/peers'
 import { UA } from '@wildebeest/backend/config/ua'
 import { type Database } from '@wildebeest/backend/database'
 import * as query from '@wildebeest/backend/database/d1/querier'
-import { insertReply } from '@wildebeest/backend/mastodon/reply'
+import {
+	deleteObjectProjectionStatements,
+	getReplyParentId,
+	refreshRepliesCount,
+	repairReplyProjection,
+} from '@wildebeest/backend/mastodon/reply_projection'
 import type { MastodonId } from '@wildebeest/backend/types'
 import { HTTPS, isGone, isNotFound, isUUID } from '@wildebeest/backend/utils'
 import { generateMastodonId } from '@wildebeest/backend/utils/id'
@@ -318,9 +323,7 @@ async function cacheObject<T extends ApObject>(
 			return null
 		})
 		if (localObjectId) {
-			await insertReply(db, { id: actorId }, { id: apId }, { id: localObjectId }).catch((err) => {
-				console.warn('failed to insert reply: ' + err)
-			})
+			await repairReplyProjection(db, actorId, apId, localObjectId)
 		}
 	}
 
@@ -410,7 +413,10 @@ async function getObjectBy<T extends ApObject>(
 	const properties = JSON.parse(row.properties) as Remote<T>
 
 	if (isNote(properties) && properties.inReplyTo) {
-		await cacheReply(domain, db, properties.inReplyTo, properties.attributedTo.toString(), 1)
+		const inReplyToId = await cacheReply(domain, db, properties.inReplyTo, properties.attributedTo.toString(), 1)
+		if (inReplyToId) {
+			await repairReplyProjection(db, row.originalActorId, row.id, inReplyToId)
+		}
 	}
 
 	return {
@@ -505,23 +511,10 @@ function getTextContentRewriter() {
 	return textContentRewriter
 }
 
-// TODO: eventually use SQLite's `ON DELETE CASCADE` but requires writing the DB
-// schema directly into D1, which D1 disallows at the moment.
-// Some context at: https://stackoverflow.com/questions/13150075/add-on-delete-cascade-behavior-to-an-sqlite3-table-after-it-has-been-created
 export async function deleteObject<T extends ApObject>(db: Database, note: T) {
 	const nodeId = note.id.toString()
-	const batch = [
-		db.prepare('DELETE FROM outbox_objects WHERE object_id=?').bind(nodeId),
-		db.prepare('DELETE FROM inbox_objects WHERE object_id=?').bind(nodeId),
-		db.prepare('DELETE FROM actor_notifications WHERE object_id=?').bind(nodeId),
-		db.prepare('DELETE FROM actor_favourites WHERE object_id=?').bind(nodeId),
-		db.prepare('DELETE FROM actor_reblogs WHERE object_id=?').bind(nodeId),
-		db.prepare('DELETE FROM actor_replies WHERE object_id=?1 OR in_reply_to_object_id=?1').bind(nodeId),
-		db.prepare('DELETE FROM idempotency_keys WHERE object_id=?').bind(nodeId),
-		db.prepare('DELETE FROM note_hashtags WHERE object_id=?').bind(nodeId),
-		db.prepare('DELETE FROM object_revisions WHERE object_id=?').bind(nodeId),
-		db.prepare('DELETE FROM objects WHERE id=?').bind(nodeId),
-	]
+	const replyParentId = await getReplyParentId(db, nodeId)
+	const batch = deleteObjectProjectionStatements(db, nodeId)
 
 	const res = await db.batch(batch)
 
@@ -529,6 +522,10 @@ export async function deleteObject<T extends ApObject>(db: Database, note: T) {
 		if (!res[i].success) {
 			throw new Error('SQL error: ' + res[i].error)
 		}
+	}
+
+	if (replyParentId) {
+		await refreshRepliesCount(db, replyParentId)
 	}
 }
 

--- a/packages/backend/src/database/d1/querier.ts
+++ b/packages/backend/src/database/d1/querier.ts
@@ -186,23 +186,6 @@ export async function insertActorPreferences(d1: D1Database, args: InsertActorPr
 	return await d1.prepare(insertActorPreferencesQuery).bind(args.id).run()
 }
 
-const insertReplyQuery = `-- name: InsertReply :exec
-INSERT INTO
-  actor_replies (id, actor_id, object_id, in_reply_to_object_id)
-VALUES
-  (?, ?, ?, ?)`
-
-export type InsertReplyParams = {
-	id: string
-	actorId: string
-	objectId: string
-	inReplyToObjectId: string
-}
-
-export async function insertReply(d1: D1Database, args: InsertReplyParams): Promise<D1Result> {
-	return await d1.prepare(insertReplyQuery).bind(args.id, args.actorId, args.objectId, args.inReplyToObjectId).run()
-}
-
 const insertActorQuery = `-- name: InsertActor :exec
 INSERT INTO
   actors ("id", "mastodon_id", "type", "username", "domain", "properties", "cdate")

--- a/packages/backend/src/mastodon/interaction_count.ts
+++ b/packages/backend/src/mastodon/interaction_count.ts
@@ -1,0 +1,46 @@
+import type { Database } from '@wildebeest/backend/database'
+
+export async function refreshRemoteObjectInteractionCount(db: Database, objectId: string): Promise<void> {
+	const { success, error } = await db
+		.prepare(
+			`
+UPDATE objects
+SET interaction_count = ${remoteInteractionCountSql()}
+WHERE id = ?
+  AND local = 0
+`
+		)
+		.bind(objectId, objectId, objectId, objectId)
+		.run()
+	if (!success) {
+		throw new Error('SQL error: ' + error)
+	}
+}
+
+export async function refreshReblogAndRemoteInteractionCounts(db: Database, objectId: string): Promise<void> {
+	const { success, error } = await db
+		.prepare(
+			`
+UPDATE objects
+SET reblogs_count = (SELECT COUNT(*) FROM actor_reblogs WHERE object_id = ?),
+    interaction_count = CASE
+      WHEN local = 0 THEN ${remoteInteractionCountSql()}
+      ELSE interaction_count
+    END
+WHERE id = ?
+`
+		)
+		.bind(objectId, objectId, objectId, objectId, objectId)
+		.run()
+	if (!success) {
+		throw new Error('SQL error: ' + error)
+	}
+}
+
+function remoteInteractionCountSql(): string {
+	return `
+        (SELECT COUNT(*) FROM actor_reblogs INNER JOIN users ON users.actor_id = actor_reblogs.actor_id WHERE actor_reblogs.object_id = ?)
+        + (SELECT COUNT(*) FROM actor_favourites INNER JOIN users ON users.actor_id = actor_favourites.actor_id WHERE actor_favourites.object_id = ?)
+        + (SELECT COUNT(*) FROM bookmarks INNER JOIN users ON users.actor_id = bookmarks.account_id WHERE bookmarks.status_id = ?)
+`
+}

--- a/packages/backend/src/mastodon/reply.ts
+++ b/packages/backend/src/mastodon/reply.ts
@@ -16,12 +16,21 @@ export async function insertReply(
 	const id = crypto.randomUUID()
 	const objectId = obj.id.toString()
 	const inReplyToObjectId = inReplyToObj.id.toString()
-	const oldReply = await db
-		.prepare(`SELECT in_reply_to_id FROM objects WHERE id = ? AND in_reply_to_id IS NOT NULL`)
-		.bind(objectId)
-		.first<{ in_reply_to_id: string }>()
 
 	const results = await db.batch([
+		db
+			.prepare(
+				`
+UPDATE objects
+SET replies_count = (
+  SELECT COUNT(*) - 1 FROM objects AS reply WHERE reply.in_reply_to_id = objects.id
+)
+WHERE id = (
+  SELECT in_reply_to_id FROM objects WHERE id = ? AND in_reply_to_id IS NOT NULL AND in_reply_to_id != ?
+)
+`
+			)
+			.bind(objectId, inReplyToObjectId),
 		db
 			.prepare(
 				`
@@ -59,21 +68,6 @@ WHERE id = ?
 `
 			)
 			.bind(inReplyToObjectId, inReplyToObjectId),
-		...(oldReply && oldReply.in_reply_to_id !== inReplyToObjectId
-			? [
-					db
-						.prepare(
-							`
-UPDATE objects
-SET replies_count = (
-  SELECT COUNT(*) FROM objects AS reply WHERE reply.in_reply_to_id = ?
-)
-WHERE id = ?
-`
-						)
-						.bind(oldReply.in_reply_to_id, oldReply.in_reply_to_id),
-				]
-			: []),
 	])
 	assertBatchSuccess(results)
 }

--- a/packages/backend/src/mastodon/reply.ts
+++ b/packages/backend/src/mastodon/reply.ts
@@ -2,9 +2,10 @@ import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import type { Actor } from '@wildebeest/backend/activitypub/actors'
 import { type ApObject } from '@wildebeest/backend/activitypub/objects'
 import { type Database } from '@wildebeest/backend/database'
-import * as query from '@wildebeest/backend/database/d1/querier'
 import { toMastodonStatusFromRow } from '@wildebeest/backend/mastodon/status'
 import type { MastodonStatus } from '@wildebeest/backend/types/status'
+
+import { assertBatchSuccess } from './utils'
 
 export async function insertReply(
 	db: Database,
@@ -13,12 +14,68 @@ export async function insertReply(
 	inReplyToObj: Pick<ApObject, 'id'>
 ): Promise<void> {
 	const id = crypto.randomUUID()
-	await query.insertReply(db, {
-		id: id.toString(),
-		actorId: actor.id.toString(),
-		objectId: obj.id.toString(),
-		inReplyToObjectId: inReplyToObj.id.toString(),
-	})
+	const objectId = obj.id.toString()
+	const inReplyToObjectId = inReplyToObj.id.toString()
+	const oldReply = await db
+		.prepare(`SELECT in_reply_to_id FROM objects WHERE id = ? AND in_reply_to_id IS NOT NULL`)
+		.bind(objectId)
+		.first<{ in_reply_to_id: string }>()
+
+	const results = await db.batch([
+		db
+			.prepare(
+				`
+UPDATE actor_replies
+SET actor_id = ?, in_reply_to_object_id = ?
+WHERE object_id = ?
+`
+			)
+			.bind(actor.id.toString(), inReplyToObjectId, objectId),
+		db
+			.prepare(
+				`
+INSERT INTO actor_replies (id, actor_id, object_id, in_reply_to_object_id)
+SELECT ?, ?, ?, ?
+WHERE NOT EXISTS (SELECT 1 FROM actor_replies WHERE object_id = ?)
+`
+			)
+			.bind(id.toString(), actor.id.toString(), objectId, inReplyToObjectId, objectId),
+		db
+			.prepare(
+				`UPDATE objects
+SET in_reply_to_id = ?,
+    in_reply_to_account_id = (SELECT original_actor_id FROM objects AS parent WHERE parent.id = ?)
+WHERE id = ?`
+			)
+			.bind(inReplyToObjectId, inReplyToObjectId, objectId),
+		db
+			.prepare(
+				`
+UPDATE objects
+SET replies_count = (
+  SELECT COUNT(*) FROM objects AS reply WHERE reply.in_reply_to_id = ?
+)
+WHERE id = ?
+`
+			)
+			.bind(inReplyToObjectId, inReplyToObjectId),
+		...(oldReply && oldReply.in_reply_to_id !== inReplyToObjectId
+			? [
+					db
+						.prepare(
+							`
+UPDATE objects
+SET replies_count = (
+  SELECT COUNT(*) FROM objects AS reply WHERE reply.in_reply_to_id = ?
+)
+WHERE id = ?
+`
+						)
+						.bind(oldReply.in_reply_to_id, oldReply.in_reply_to_id),
+				]
+			: []),
+	])
+	assertBatchSuccess(results)
 }
 
 export async function getReplies(domain: string, db: Database, obj: ApObject): Promise<Array<MastodonStatus>> {
@@ -41,15 +98,15 @@ SELECT
   outbox_objects.cc as publisher_cc,
 
   (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
-  (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
-  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count
+  COALESCE(objects.reblogs_count, 0) as reblogs_count,
+  COALESCE(objects.replies_count, 0) as replies_count
 FROM outbox_objects
-  INNER JOIN actor_replies ON actor_replies.object_id = outbox_objects.object_id
-  INNER JOIN objects ON objects.id = actor_replies.object_id
-  INNER JOIN actors ON actors.id = actor_replies.actor_id
+  INNER JOIN objects ON objects.id = outbox_objects.object_id
+  INNER JOIN actors ON actors.id = objects.original_actor_id
 WHERE
   objects.type = 'Note'
-  AND actor_replies.in_reply_to_object_id = ?1
+  AND objects.in_reply_to_id = ?1
+  AND outbox_objects.actor_id = objects.original_actor_id
   AND (EXISTS(SELECT 1 FROM json_each(outbox_objects.'to') WHERE json_each.value IN ${db.qb.set('?3')})
         OR EXISTS(SELECT 1 FROM json_each(outbox_objects.cc) WHERE json_each.value IN ${db.qb.set('?3')}))
 ORDER BY ${db.qb.timeNormalize('outbox_objects.published_date')} DESC

--- a/packages/backend/src/mastodon/reply_projection.ts
+++ b/packages/backend/src/mastodon/reply_projection.ts
@@ -1,0 +1,56 @@
+import type { Database } from '@wildebeest/backend/database'
+import { insertReply } from '@wildebeest/backend/mastodon/reply'
+
+export async function repairReplyProjection(
+	db: Database,
+	actorId: string | URL,
+	objectId: string | URL,
+	inReplyToObjectId: string | URL
+): Promise<void> {
+	await insertReply(db, { id: new URL(actorId) }, { id: new URL(objectId) }, { id: new URL(inReplyToObjectId) }).catch(
+		(err) => {
+			console.warn('failed to repair reply: ' + err)
+		}
+	)
+}
+
+export async function getReplyParentId(db: Database, objectId: string): Promise<string | null> {
+	const reply = await db
+		.prepare(`SELECT in_reply_to_id FROM objects WHERE id = ? AND in_reply_to_id IS NOT NULL`)
+		.bind(objectId)
+		.first<{ in_reply_to_id: string }>()
+	return reply?.in_reply_to_id ?? null
+}
+
+export function deleteObjectProjectionStatements(db: Database, objectId: string): D1PreparedStatement[] {
+	return [
+		db.prepare('DELETE FROM outbox_objects WHERE object_id=?').bind(objectId),
+		db.prepare('DELETE FROM inbox_objects WHERE object_id=?').bind(objectId),
+		db.prepare('DELETE FROM actor_notifications WHERE object_id=?').bind(objectId),
+		db.prepare('DELETE FROM actor_favourites WHERE object_id=?').bind(objectId),
+		db.prepare('DELETE FROM actor_reblogs WHERE object_id=?').bind(objectId),
+		db.prepare('DELETE FROM bookmarks WHERE status_id=?').bind(objectId),
+		db
+			.prepare(`UPDATE objects SET in_reply_to_id = NULL, in_reply_to_account_id = NULL WHERE in_reply_to_id = ?`)
+			.bind(objectId),
+		db.prepare('DELETE FROM actor_replies WHERE object_id=?1 OR in_reply_to_object_id=?1').bind(objectId),
+		db.prepare('DELETE FROM idempotency_keys WHERE object_id=?').bind(objectId),
+		db.prepare('DELETE FROM note_hashtags WHERE object_id=?').bind(objectId),
+		db.prepare('DELETE FROM object_revisions WHERE object_id=?').bind(objectId),
+		db.prepare('DELETE FROM objects WHERE id=?').bind(objectId),
+	]
+}
+
+export async function refreshRepliesCount(db: Database, objectId: string): Promise<void> {
+	const { success, error } = await db
+		.prepare(
+			`UPDATE objects
+SET replies_count = (SELECT COUNT(*) FROM objects AS replies WHERE replies.in_reply_to_id = ?)
+WHERE id = ?`
+		)
+		.bind(objectId, objectId)
+		.run()
+	if (!success) {
+		throw new Error('SQL error: ' + error)
+	}
+}

--- a/packages/backend/src/mastodon/reply_projection.ts
+++ b/packages/backend/src/mastodon/reply_projection.ts
@@ -7,11 +7,12 @@ export async function repairReplyProjection(
 	objectId: string | URL,
 	inReplyToObjectId: string | URL
 ): Promise<void> {
-	await insertReply(db, { id: new URL(actorId) }, { id: new URL(objectId) }, { id: new URL(inReplyToObjectId) }).catch(
-		(err) => {
-			console.warn('failed to repair reply: ' + err)
-		}
-	)
+	try {
+		await insertReply(db, { id: new URL(actorId) }, { id: new URL(objectId) }, { id: new URL(inReplyToObjectId) })
+	} catch (err) {
+		console.warn('failed to repair reply: ' + err)
+		throw err
+	}
 }
 
 export async function getReplyParentId(db: Database, objectId: string): Promise<string | null> {

--- a/schema.sql
+++ b/schema.sql
@@ -137,6 +137,9 @@ CREATE INDEX "objects_original_actor_id" ON "objects" ("original_actor_id");
 
 CREATE INDEX "objects_original_object_id" ON "objects" ("original_object_id");
 
+CREATE INDEX "objects_in_reply_to_id" ON "objects" ("in_reply_to_id")
+  WHERE "in_reply_to_id" IS NOT NULL;
+
 CREATE INDEX "objects_cleanup" ON "objects" ("local", "expires_at", "interaction_count")
   WHERE "local" = 0;
 
@@ -227,6 +230,8 @@ CREATE TABLE
   );
 
 CREATE INDEX "actor_replies_in_reply_to_object_id" ON "actor_replies" ("in_reply_to_object_id");
+
+CREATE UNIQUE INDEX "actor_replies_unique_object_id" ON "actor_replies" ("object_id");
 
 CREATE TABLE
   peers ("domain" TEXT UNIQUE NOT NULL);
@@ -328,6 +333,8 @@ CREATE TABLE
 
 CREATE INDEX "outbox_objects_actor_id" ON "outbox_objects" ("actor_id");
 
+CREATE INDEX "outbox_objects_object_id_published_date" ON "outbox_objects" ("object_id", "published_date");
+
 CREATE INDEX "outbox_objects_to" ON "outbox_objects" ("to");
 
 CREATE INDEX "outbox_objects_cc" ON "outbox_objects" ("cc");
@@ -423,6 +430,8 @@ CREATE TABLE
   );
 
 CREATE UNIQUE INDEX "blocks_unique" ON "blocks" ("account_id", "target_account_id");
+
+CREATE INDEX "blocks_target_account_id_account_id" ON "blocks" ("target_account_id", "account_id");
 
 CREATE TABLE
   mutes (


### PR DESCRIPTION
## Summary
- Backfill `objects.in_reply_to_id`, reply account IDs, reply counts, and reblog counts before read paths depend on projected columns.
- Add indexes for reply lookup, reblog ordering, relationship visibility checks, and a unique reply projection per object.
- Move reply projection maintenance into Mastodon helpers so create/cache/delete paths keep counts in sync.

## Rollout notes
- Apply migrations before deploying Workers that read `objects.in_reply_to_id`.
- Migration `0038` removes duplicate `actor_replies` rows before creating the unique index.

## Verification
- `pnpm run test`
- pre-commit `pretty` and `lint`
- pre-push `test`
