### PR TITLE
Add social interaction APIs

### DIFF
--- a/packages/backend/src/activitypub/activities/announce.test.ts
+++ b/packages/backend/src/activitypub/activities/announce.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert/strict'
 
-import { AnnounceActivity, PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
+import { AnnounceActivity, PUBLIC_GROUP, UndoActivity } from '@wildebeest/backend/activitypub/activities'
 import * as activityHandler from '@wildebeest/backend/activitypub/activities/handle'
 import { getApId } from '@wildebeest/backend/activitypub/objects'
 import { Note } from '@wildebeest/backend/activitypub/objects/note'
@@ -74,7 +74,7 @@ describe('Announce', () => {
 		const remoteActorId = 'https://example.com/actor'
 		const objectId = 'https://example.com/some-object'
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === remoteActorId) {
 					return new Response(
@@ -150,7 +150,7 @@ describe('Announce', () => {
 		const remoteActorId = 'https://example.com/actor'
 		const remoteActorFollowers = 'https://example.com/actor/followers'
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === remoteActorId) {
 					return new Response(
@@ -452,10 +452,251 @@ describe('Announce', () => {
 		})
 	})
 
+	test('undo announce removes reblog', async () => {
+		const remoteActorId = 'https://example.com/actor'
+		const objectId = 'https://example.com/some-object'
+		globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
+			if (input instanceof URL || typeof input === 'string') {
+				if (input.toString() === remoteActorId) {
+					return new Response(
+						JSON.stringify({
+							id: remoteActorId,
+							icon: { url: 'https://img.com' },
+							type: 'Person',
+							preferredUsername: 'actor',
+						})
+					)
+				}
+
+				if (input.toString() === objectId) {
+					return new Response(
+						JSON.stringify({
+							id: objectId,
+							type: 'Note',
+							content: 'foo',
+							source: {
+								content: 'foo',
+								mediaType: 'text/plain',
+							},
+							attachment: [],
+							sensitive: false,
+							attributedTo: remoteActorId,
+							to: [PUBLIC_GROUP],
+							cc: [],
+						} satisfies Note)
+					)
+				}
+
+				throw new Error('unexpected request to ' + input.toString())
+			}
+			throw new Error('unexpected request to ' + input.url)
+		}
+
+		const db = makeDB()
+		await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
+
+		const announce: AnnounceActivity = {
+			type: 'Announce',
+			id: createActivityId(domain),
+			actor: getApId(remoteActorId),
+			to: [PUBLIC_GROUP],
+			cc: [],
+			object: getApId(objectId),
+		}
+		await activityHandler.handle(domain, announce, db, userKEK, adminEmail, vapidKeys)
+
+		const undo: UndoActivity<AnnounceActivity> = {
+			type: 'Undo',
+			id: createActivityId(domain),
+			actor: getApId(remoteActorId),
+			object: announce,
+		}
+		await activityHandler.handle(domain, undo, db, userKEK, adminEmail, vapidKeys)
+
+		const { count } = await db
+			.prepare('SELECT count(*) as count FROM actor_reblogs')
+			.first<{ count: number }>()
+			.then((row) => {
+				assert.ok(row)
+				return row
+			})
+		assert.equal(count, 0)
+	})
+
+	test('stale embedded undo announce does not remove newer reblog', async () => {
+		const remoteActorId = 'https://example.com/actor'
+		const objectId = 'https://example.com/some-object'
+		globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
+			if (input instanceof URL || typeof input === 'string') {
+				if (input.toString() === remoteActorId) {
+					return new Response(
+						JSON.stringify({
+							id: remoteActorId,
+							icon: { url: 'https://img.com' },
+							type: 'Person',
+							preferredUsername: 'actor',
+						})
+					)
+				}
+
+				if (input.toString() === objectId) {
+					return new Response(
+						JSON.stringify({
+							id: objectId,
+							type: 'Note',
+							content: 'foo',
+							source: {
+								content: 'foo',
+								mediaType: 'text/plain',
+							},
+							attachment: [],
+							sensitive: false,
+							attributedTo: remoteActorId,
+							to: [PUBLIC_GROUP],
+							cc: [],
+						} satisfies Note)
+					)
+				}
+
+				throw new Error('unexpected request to ' + input.toString())
+			}
+			throw new Error('unexpected request to ' + input.url)
+		}
+
+		const db = makeDB()
+		await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
+
+		const oldAnnounce: AnnounceActivity = {
+			type: 'Announce',
+			id: createActivityId(domain),
+			actor: getApId(remoteActorId),
+			to: [PUBLIC_GROUP],
+			cc: [],
+			object: getApId(objectId),
+		}
+		await activityHandler.handle(domain, oldAnnounce, db, userKEK, adminEmail, vapidKeys)
+		await activityHandler.handle(
+			domain,
+			{
+				type: 'Undo',
+				id: createActivityId(domain),
+				actor: getApId(remoteActorId),
+				object: oldAnnounce.id,
+			} satisfies UndoActivity,
+			db,
+			userKEK,
+			adminEmail,
+			vapidKeys
+		)
+
+		const newAnnounce: AnnounceActivity = {
+			type: 'Announce',
+			id: createActivityId(domain),
+			actor: getApId(remoteActorId),
+			to: [PUBLIC_GROUP],
+			cc: [],
+			object: getApId(objectId),
+		}
+		await activityHandler.handle(domain, newAnnounce, db, userKEK, adminEmail, vapidKeys)
+		await activityHandler.handle(
+			domain,
+			{
+				type: 'Undo',
+				id: createActivityId(domain),
+				actor: getApId(remoteActorId),
+				object: oldAnnounce,
+			} satisfies UndoActivity<AnnounceActivity>,
+			db,
+			userKEK,
+			adminEmail,
+			vapidKeys
+		)
+
+		const { count } = await db
+			.prepare('SELECT count(*) as count FROM actor_reblogs')
+			.first<{ count: number }>()
+			.then((row) => {
+				assert.ok(row)
+				return row
+			})
+		assert.equal(count, 1)
+	})
+
+	test('undo announce by activity id removes reblog', async () => {
+		const remoteActorId = 'https://example.com/actor'
+		const objectId = 'https://example.com/some-object'
+		globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
+			if (input instanceof URL || typeof input === 'string') {
+				if (input.toString() === remoteActorId) {
+					return new Response(
+						JSON.stringify({
+							id: remoteActorId,
+							icon: { url: 'https://img.com' },
+							type: 'Person',
+							preferredUsername: 'actor',
+						})
+					)
+				}
+
+				if (input.toString() === objectId) {
+					return new Response(
+						JSON.stringify({
+							id: objectId,
+							type: 'Note',
+							content: 'foo',
+							source: {
+								content: 'foo',
+								mediaType: 'text/plain',
+							},
+							attachment: [],
+							sensitive: false,
+							attributedTo: remoteActorId,
+							to: [PUBLIC_GROUP],
+							cc: [],
+						} satisfies Note)
+					)
+				}
+
+				throw new Error('unexpected request to ' + input.toString())
+			}
+			throw new Error('unexpected request to ' + input.url)
+		}
+
+		const db = makeDB()
+		await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
+
+		const announce: AnnounceActivity = {
+			type: 'Announce',
+			id: createActivityId(domain),
+			actor: getApId(remoteActorId),
+			to: [PUBLIC_GROUP],
+			cc: [],
+			object: getApId(objectId),
+		}
+		await activityHandler.handle(domain, announce, db, userKEK, adminEmail, vapidKeys)
+
+		const undo: UndoActivity = {
+			type: 'Undo',
+			id: createActivityId(domain),
+			actor: getApId(remoteActorId),
+			object: announce.id,
+		}
+		await activityHandler.handle(domain, undo, db, userKEK, adminEmail, vapidKeys)
+
+		const { count } = await db
+			.prepare('SELECT count(*) as count FROM actor_reblogs')
+			.first<{ count: number }>()
+			.then((row) => {
+				assert.ok(row)
+				return row
+			})
+		assert.equal(count, 0)
+	})
+
 	test('duplicated announce', async () => {
 		const remoteActorId = 'https://example.com/actor'
 		const objectId = 'https://example.com/some-object'
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === remoteActorId) {
 					return new Response(

--- a/packages/backend/src/activitypub/activities/announce.ts
+++ b/packages/backend/src/activitypub/activities/announce.ts
@@ -77,10 +77,11 @@ export async function handleAnnounceActivity(
 		return
 	}
 
-	const notifId = await createNotification(db, 'reblog', rebloggedActor, actor, obj)
+	const created = await createReblog(db, actor, obj, activity, activity.published)
+	if (!created) {
+		return
+	}
 
-	await Promise.all([
-		createReblog(db, actor, obj, activity, activity.published),
-		sendReblogNotification(db, actor, rebloggedActor, notifId, adminEmail, vapidKeys),
-	])
+	const notifId = await createNotification(db, 'reblog', rebloggedActor, actor, obj)
+	await sendReblogNotification(db, actor, rebloggedActor, notifId, adminEmail, vapidKeys)
 }

--- a/packages/backend/src/activitypub/activities/handle.ts
+++ b/packages/backend/src/activitypub/activities/handle.ts
@@ -7,6 +7,7 @@ import {
 	isFollowActivity,
 	isLikeActivity,
 	isMoveActivity,
+	isUndoActivity,
 	isUpdateActivity,
 } from '@wildebeest/backend/activitypub/activities'
 import { handleAcceptActivity } from '@wildebeest/backend/activitypub/activities/accept'
@@ -16,6 +17,7 @@ import { handleDeleteActivity } from '@wildebeest/backend/activitypub/activities
 import { handleFollowActivity } from '@wildebeest/backend/activitypub/activities/follow'
 import { handleLikeActivity } from '@wildebeest/backend/activitypub/activities/like'
 import { handleMoveActivity } from '@wildebeest/backend/activitypub/activities/move'
+import { handleUndoActivity } from '@wildebeest/backend/activitypub/activities/undo'
 import { handleUpdateActivity } from '@wildebeest/backend/activitypub/activities/update'
 import { Database } from '@wildebeest/backend/database'
 import { JWK } from '@wildebeest/backend/webpush/jwk'
@@ -51,6 +53,9 @@ export async function handle(
 	}
 	if (isMoveActivity(activity)) {
 		return await handleMoveActivity(domain, activity, db)
+	}
+	if (isUndoActivity(activity)) {
+		return await handleUndoActivity(domain, activity, db)
 	}
 	console.warn(`Unsupported activity: ${activity.type}`)
 }

--- a/packages/backend/src/activitypub/activities/index.ts
+++ b/packages/backend/src/activitypub/activities/index.ts
@@ -87,6 +87,10 @@ export function isMoveActivity(obj: ApObject): obj is MoveActivity {
 	return getApType(obj) === 'Move'
 }
 
+export function isUndoActivity(obj: ApObject): obj is UndoActivity {
+	return getApType(obj) === 'Undo'
+}
+
 export function getActivityObject(activity: Activity): ApObject {
 	if (typeof activity.object === 'string' || activity.object instanceof URL) {
 		throw new Error('`activity.object` must be of type object')

--- a/packages/backend/src/activitypub/activities/undo.ts
+++ b/packages/backend/src/activitypub/activities/undo.ts
@@ -1,8 +1,15 @@
-import { insertActivity, UndoActivity } from '@wildebeest/backend/activitypub/activities'
+import {
+	AnnounceActivity,
+	getActivityObject,
+	insertActivity,
+	isAnnounceActivity,
+	UndoActivity,
+} from '@wildebeest/backend/activitypub/activities'
 import { createFollowActivity } from '@wildebeest/backend/activitypub/activities/follow'
-import { Actor } from '@wildebeest/backend/activitypub/actors'
-import { ApObject } from '@wildebeest/backend/activitypub/objects'
+import { Actor, getAndCacheActor } from '@wildebeest/backend/activitypub/actors'
+import { ApObject, getApId } from '@wildebeest/backend/activitypub/objects'
 import { Database } from '@wildebeest/backend/database'
+import { deleteReblogByActivityId } from '@wildebeest/backend/mastodon/reblog'
 
 export async function createUnfollowActivity(
 	db: Database,
@@ -16,4 +23,46 @@ export async function createUnfollowActivity(
 		actor: actor.id,
 		object: await createFollowActivity(db, domain, actor, object),
 	})
+}
+
+export async function createUndoAnnounceActivity(
+	db: Database,
+	domain: string,
+	actor: Actor,
+	announce: AnnounceActivity
+): Promise<UndoActivity<AnnounceActivity>> {
+	return await insertActivity(db, domain, actor, {
+		'@context': 'https://www.w3.org/ns/activitystreams',
+		type: 'Undo',
+		actor: actor.id,
+		object: announce,
+		to: announce.to,
+		cc: announce.cc,
+	})
+}
+
+export async function handleUndoActivity(_domain: string, activity: UndoActivity, db: Database) {
+	const actorId = getApId(activity.actor)
+	const actor = await getAndCacheActor(actorId, db)
+	if (!actor) {
+		console.warn(`failed to retrieve actor ${actorId}`)
+		return
+	}
+
+	if (typeof activity.object === 'string' || activity.object instanceof URL) {
+		await deleteReblogByActivityId(db, actor, getApId(activity.object))
+		return
+	}
+
+	const object = getActivityObject(activity)
+	if (!isAnnounceActivity(object)) {
+		console.warn(`Unsupported Undo object: ${object.type}`)
+		return
+	}
+	if (getApId(object.actor).toString() !== actor.id.toString()) {
+		console.warn('Undo Announce actor mismatch')
+		return
+	}
+
+	await deleteReblogByActivityId(db, actor, getApId(object.id))
 }

--- a/packages/backend/src/activitypub/deliver.ts
+++ b/packages/backend/src/activitypub/deliver.ts
@@ -53,9 +53,10 @@ export async function deliverFollowers(
 	userKEK: string,
 	from: Actor,
 	activity: Activity,
-	queue: Queue<DeliverMessageBody>
+	queue: Queue<DeliverMessageBody>,
+	excludeActorIds: Set<string> = new Set()
 ) {
-	const followers = await getFollowerIds(db, from)
+	const followers = (await getFollowerIds(db, from)).filter((id) => !excludeActorIds.has(id))
 	if (followers.length === 0) {
 		// No one is following the user so no updates to send. Sad.
 		return

--- a/packages/backend/src/activitypub/deliver.ts
+++ b/packages/backend/src/activitypub/deliver.ts
@@ -45,6 +45,14 @@ export async function deliverToActor<T extends Activity>(
 	console.log(`${to.inbox} returned 200`)
 }
 
+export async function deliverSafely(label: string, deliver: () => Promise<unknown>): Promise<void> {
+	try {
+		await deliver()
+	} catch (err) {
+		console.warn(`failed to deliver ${label}:`, err)
+	}
+}
+
 // TODO: eventually move this to the queue worker, the backend can send a message
 // to a collection (followers) and the worker creates the individual messages. More
 // reliable and scalable.

--- a/packages/backend/src/mastodon/account_relationship.ts
+++ b/packages/backend/src/mastodon/account_relationship.ts
@@ -1,0 +1,119 @@
+import type { Actor } from '@wildebeest/backend/activitypub/actors'
+import type { Database } from '@wildebeest/backend/database'
+import type { MastodonId } from '@wildebeest/backend/types'
+
+import { getResultsField } from './utils'
+
+type RelationshipTable = 'blocks' | 'mutes'
+
+const TABLE_NAME: Record<RelationshipTable, string> = {
+	blocks: 'blocks',
+	mutes: 'mutes',
+}
+
+export async function insertAccountRelationship(
+	db: Database,
+	table: RelationshipTable,
+	actor: Actor,
+	target: Actor,
+	options: { hideNotifications?: boolean } = {}
+): Promise<void> {
+	const isMute = table === 'mutes'
+	const hideNotifications = options.hideNotifications ?? true
+	const statement = isMute
+		? db
+				.prepare(
+					`
+INSERT INTO mutes (id, account_id, target_account_id, hide_notifications)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (account_id, target_account_id) DO UPDATE SET hide_notifications = excluded.hide_notifications
+`
+				)
+				.bind(crypto.randomUUID(), actor.id.toString(), target.id.toString(), hideNotifications ? 1 : 0)
+		: db
+				.prepare(
+					db.qb.insertOrIgnore(`
+INTO blocks (id, account_id, target_account_id)
+VALUES (?, ?, ?)
+`)
+				)
+				.bind(crypto.randomUUID(), actor.id.toString(), target.id.toString())
+
+	const { success, error } = await statement.run()
+	if (!success) {
+		throw new Error('SQL error: ' + error)
+	}
+}
+
+export async function deleteAccountRelationship(
+	db: Database,
+	table: RelationshipTable,
+	actor: Actor,
+	target: Actor
+): Promise<void> {
+	const tableName = TABLE_NAME[table]
+	const { success, error } = await db
+		.prepare(`DELETE FROM ${tableName} WHERE account_id = ? AND target_account_id = ?`)
+		.bind(actor.id.toString(), target.id.toString())
+		.run()
+	if (!success) {
+		throw new Error('SQL error: ' + error)
+	}
+}
+
+export function getTargetMastodonIds(
+	db: Database,
+	table: RelationshipTable,
+	actor: Actor,
+	{ limit, maxId, targetIds }: { limit: number; maxId?: MastodonId; targetIds?: MastodonId[] } = { limit: 40 }
+): Promise<MastodonId[]> {
+	if (targetIds?.length === 0) {
+		return Promise.resolve([])
+	}
+
+	const tableName = TABLE_NAME[table]
+	const targetFilter = targetIds ? `AND actors.mastodon_id IN (${targetIds.map(() => '?').join(', ')})` : ''
+	const statement = db
+		.prepare(
+			`
+SELECT actors.mastodon_id
+FROM ${tableName}
+INNER JOIN actors ON actors.id = ${tableName}.target_account_id
+WHERE ${tableName}.account_id = ?
+  AND (? IS NULL OR actors.mastodon_id < ?)
+  ${targetFilter}
+ORDER BY actors.mastodon_id DESC
+LIMIT ?
+`
+		)
+		.bind(actor.id.toString(), maxId ?? null, maxId ?? null, ...(targetIds ?? []), limit)
+
+	return getResultsField(statement, 'mastodon_id')
+}
+
+export function getSourceMastodonIdsForTargets(
+	db: Database,
+	table: RelationshipTable,
+	actor: Actor,
+	targetIds: MastodonId[]
+): Promise<MastodonId[]> {
+	if (targetIds.length === 0) {
+		return Promise.resolve([])
+	}
+
+	const tableName = TABLE_NAME[table]
+	const placeholders = targetIds.map(() => '?').join(', ')
+	const statement = db
+		.prepare(
+			`
+SELECT actors.mastodon_id
+FROM ${tableName}
+INNER JOIN actors ON actors.id = ${tableName}.account_id
+WHERE ${tableName}.target_account_id = ?
+  AND actors.mastodon_id IN (${placeholders})
+`
+		)
+		.bind(actor.id.toString(), ...targetIds)
+
+	return getResultsField(statement, 'mastodon_id')
+}

--- a/packages/backend/src/mastodon/announce_delivery.ts
+++ b/packages/backend/src/mastodon/announce_delivery.ts
@@ -1,6 +1,6 @@
 import type { AnnounceActivity, UndoActivity } from '@wildebeest/backend/activitypub/activities'
 import { getAndCacheActor, type Actor, type Person } from '@wildebeest/backend/activitypub/actors'
-import { deliverFollowers, deliverToActor } from '@wildebeest/backend/activitypub/deliver'
+import { deliverFollowers, deliverSafely, deliverToActor } from '@wildebeest/backend/activitypub/deliver'
 import {
 	getApId,
 	isLocalObject,
@@ -58,19 +58,27 @@ export async function deliverCreatedAnnounce(
 ): Promise<void> {
 	if (!targetActor) {
 		if (addressesFollowers(activity, actor)) {
-			await deliverFollowers(db, userKEK, actor, activity, queue)
+			await deliverSafely('Announce to followers', () => deliverFollowers(db, userKEK, actor, activity, queue))
 		}
 		return
 	}
 
-	const deliveries: Promise<unknown>[] = []
+	const deliveries: Promise<void>[] = []
 	const targetActorId = targetActor.id.toString()
 	if (addressesActor(activity, targetActorId)) {
 		const signingKey = await getSigningKey(userKEK, db, actor)
-		deliveries.push(deliverToActor(signingKey, actor, targetActor, activity, domain))
+		deliveries.push(
+			deliverSafely(`Announce to ${targetActorId}`, () =>
+				deliverToActor(signingKey, actor, targetActor, activity, domain)
+			)
+		)
 	}
 	if (addressesFollowers(activity, actor)) {
-		deliveries.push(deliverFollowers(db, userKEK, actor, activity, queue, new Set([targetActorId])))
+		deliveries.push(
+			deliverSafely('Announce to followers', () =>
+				deliverFollowers(db, userKEK, actor, activity, queue, new Set([targetActorId]))
+			)
+		)
 	}
 	await Promise.all(deliveries)
 }
@@ -85,7 +93,7 @@ export async function deliverUndoAnnounce(
 	domain: string,
 	targetActor: Actor | undefined
 ): Promise<void> {
-	const deliveries: Promise<unknown>[] = []
+	const deliveries: Promise<void>[] = []
 	const excludeActorIds = new Set<string>()
 
 	if (targetActor) {
@@ -93,11 +101,19 @@ export async function deliverUndoAnnounce(
 		excludeActorIds.add(targetActorId)
 		if (addressesActor(reblogActivity, targetActorId)) {
 			const signingKey = await getSigningKey(userKEK, db, actor)
-			deliveries.push(deliverToActor<UndoActivity>(signingKey, actor, targetActor, undoActivity, domain))
+			deliveries.push(
+				deliverSafely(`Undo Announce to ${targetActorId}`, () =>
+					deliverToActor<UndoActivity>(signingKey, actor, targetActor, undoActivity, domain)
+				)
+			)
 		}
 	}
 	if (addressesFollowers(reblogActivity, actor)) {
-		deliveries.push(deliverFollowers(db, userKEK, actor, undoActivity, queue, excludeActorIds))
+		deliveries.push(
+			deliverSafely('Undo Announce to followers', () =>
+				deliverFollowers(db, userKEK, actor, undoActivity, queue, excludeActorIds)
+			)
+		)
 	}
 
 	await Promise.all(deliveries)

--- a/packages/backend/src/mastodon/announce_delivery.ts
+++ b/packages/backend/src/mastodon/announce_delivery.ts
@@ -1,0 +1,104 @@
+import type { AnnounceActivity, UndoActivity } from '@wildebeest/backend/activitypub/activities'
+import { getAndCacheActor, type Actor, type Person } from '@wildebeest/backend/activitypub/actors'
+import { deliverFollowers, deliverToActor } from '@wildebeest/backend/activitypub/deliver'
+import {
+	getApId,
+	isLocalObject,
+	originalActorIdSymbol,
+	originalObjectIdSymbol,
+} from '@wildebeest/backend/activitypub/objects'
+import type { Note } from '@wildebeest/backend/activitypub/objects/note'
+import type { Database } from '@wildebeest/backend/database'
+import { getSigningKey } from '@wildebeest/backend/mastodon/account'
+import type { DeliverMessageBody, Queue } from '@wildebeest/backend/types'
+import { toArray } from '@wildebeest/backend/utils'
+
+export function addressesActor(activity: Pick<AnnounceActivity, 'to' | 'cc'>, actorId: string): boolean {
+	return [...toArray(activity.to ?? []), ...toArray(activity.cc ?? [])].some(
+		(target) => getApId(target).toString() === actorId
+	)
+}
+
+export function addressesFollowers(
+	activity: Pick<AnnounceActivity, 'to' | 'cc'>,
+	actor: Pick<Person, 'followers'>
+): boolean {
+	return addressesActor(activity, actor.followers.toString())
+}
+
+export async function getRemoteAnnounceTargetActor(
+	db: Database,
+	domain: string,
+	actor: Pick<Actor, 'id'>,
+	obj: Pick<Note, 'id'> & Pick<Note, typeof originalActorIdSymbol | typeof originalObjectIdSymbol>,
+	{ skipSelf }: { skipSelf: boolean }
+): Promise<Actor | null | undefined> {
+	const originalObjectId = new URL(obj[originalObjectIdSymbol] ?? obj.id.toString())
+	if (isLocalObject(domain, originalObjectId)) {
+		return undefined
+	}
+	const originalActorId = obj[originalActorIdSymbol]
+	if (!originalActorId) {
+		return null
+	}
+	if (skipSelf && originalActorId === actor.id.toString()) {
+		return undefined
+	}
+	return getAndCacheActor(new URL(originalActorId), db)
+}
+
+export async function deliverCreatedAnnounce(
+	db: Database,
+	userKEK: string,
+	actor: Person,
+	activity: AnnounceActivity,
+	queue: Queue<DeliverMessageBody>,
+	domain: string,
+	targetActor: Actor | undefined
+): Promise<void> {
+	if (!targetActor) {
+		if (addressesFollowers(activity, actor)) {
+			await deliverFollowers(db, userKEK, actor, activity, queue)
+		}
+		return
+	}
+
+	const deliveries: Promise<unknown>[] = []
+	const targetActorId = targetActor.id.toString()
+	if (addressesActor(activity, targetActorId)) {
+		const signingKey = await getSigningKey(userKEK, db, actor)
+		deliveries.push(deliverToActor(signingKey, actor, targetActor, activity, domain))
+	}
+	if (addressesFollowers(activity, actor)) {
+		deliveries.push(deliverFollowers(db, userKEK, actor, activity, queue, new Set([targetActorId])))
+	}
+	await Promise.all(deliveries)
+}
+
+export async function deliverUndoAnnounce(
+	db: Database,
+	userKEK: string,
+	actor: Person,
+	reblogActivity: AnnounceActivity,
+	undoActivity: UndoActivity,
+	queue: Queue<DeliverMessageBody>,
+	domain: string,
+	targetActor: Actor | undefined
+): Promise<void> {
+	const deliveries: Promise<unknown>[] = []
+	const excludeActorIds = new Set<string>()
+
+	if (targetActor) {
+		const targetActorId = targetActor.id.toString()
+		excludeActorIds.add(targetActorId)
+		if (addressesActor(reblogActivity, targetActorId)) {
+			const signingKey = await getSigningKey(userKEK, db, actor)
+			deliveries.push(deliverToActor<UndoActivity>(signingKey, actor, targetActor, undoActivity, domain))
+		}
+	}
+	if (addressesFollowers(reblogActivity, actor)) {
+		deliveries.push(deliverFollowers(db, userKEK, actor, undoActivity, queue, excludeActorIds))
+	}
+
+	await Promise.all(deliveries)
+}

--- a/packages/backend/src/mastodon/block.ts
+++ b/packages/backend/src/mastodon/block.ts
@@ -1,0 +1,54 @@
+import type { Actor } from '@wildebeest/backend/activitypub/actors'
+import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { type Database } from '@wildebeest/backend/database'
+import type { MastodonId } from '@wildebeest/backend/types'
+
+import {
+	deleteAccountRelationship,
+	getSourceMastodonIdsForTargets,
+	getTargetMastodonIds,
+	insertAccountRelationship,
+} from './account_relationship'
+import { removeFollowing } from './follow'
+
+export async function insertBlock(db: Database, actor: Actor, target: Actor) {
+	await insertAccountRelationship(db, 'blocks', actor, target)
+}
+
+export async function removeBlockRelatedFollows(db: Database, actor: Actor, target: Actor) {
+	await removeFollowing(db, actor, target)
+	await removeFollowing(db, target, actor)
+}
+
+export async function deleteBlock(db: Database, actor: Actor, target: Actor) {
+	await deleteAccountRelationship(db, 'blocks', actor, target)
+}
+
+export function getBlockedMastodonIds(
+	db: Database,
+	actor: Actor,
+	options: { limit: number; maxId?: MastodonId; targetIds?: MastodonId[] } = { limit: 40 }
+): Promise<MastodonId[]> {
+	return getTargetMastodonIds(db, 'blocks', actor, options)
+}
+
+export function getBlockedByMastodonIds(db: Database, actor: Actor, targetIds: MastodonId[]): Promise<MastodonId[]> {
+	return getSourceMastodonIdsForTargets(db, 'blocks', actor, targetIds)
+}
+
+export async function hasBlockBetween(db: Database, actor: Actor, target: Actor): Promise<boolean> {
+	const row = await db
+		.prepare(
+			`SELECT count(*) > 0 as blocked
+FROM blocks
+WHERE (account_id = ? AND target_account_id = ?)
+   OR (account_id = ? AND target_account_id = ?)`
+		)
+		.bind(actor.id.toString(), target.id.toString(), target.id.toString(), actor.id.toString())
+		.first<{ blocked: 1 | 0 }>()
+	return row?.blocked === 1
+}
+
+export function isSelfBlock(actor: Actor, target: Actor): boolean {
+	return actor[mastodonIdSymbol] === target[mastodonIdSymbol]
+}

--- a/packages/backend/src/mastodon/bookmark.ts
+++ b/packages/backend/src/mastodon/bookmark.ts
@@ -5,7 +5,7 @@ import { type Database } from '@wildebeest/backend/database'
 import { refreshRemoteObjectInteractionCount } from './interaction_count'
 import { assertBatchSuccess, getResultsField } from './utils'
 
-export async function insertLike(db: Database, actor: Pick<Actor, 'id'>, obj: Pick<ApObject, 'id'>): Promise<boolean> {
+export async function insertBookmark(db: Database, actor: Pick<Actor, 'id'>, obj: Pick<ApObject, 'id'>) {
 	const id = crypto.randomUUID()
 	const actorId = actor.id.toString()
 	const objectId = obj.id.toString()
@@ -14,7 +14,7 @@ export async function insertLike(db: Database, actor: Pick<Actor, 'id'>, obj: Pi
 		db
 			.prepare(
 				db.qb.insertOrIgnore(`
-INTO actor_favourites (id, actor_id, object_id)
+INTO bookmarks (id, account_id, status_id)
 VALUES (?, ?, ?)
 `)
 			)
@@ -27,17 +27,16 @@ SET interaction_count = interaction_count + 1
 WHERE id = ?
   AND local = 0
   AND EXISTS (SELECT 1 FROM users WHERE users.actor_id = ?)
-  AND EXISTS (SELECT 1 FROM actor_favourites WHERE id = ?)
+  AND EXISTS (SELECT 1 FROM bookmarks WHERE id = ?)
 `
 			)
 			.bind(objectId, actorId, id),
 	])
 	assertBatchSuccess(results)
 	await refreshRemoteObjectInteractionCount(db, objectId)
-	return results[0].meta.changes === 1
 }
 
-export async function deleteLike(db: Database, actor: Pick<Actor, 'id'>, obj: Pick<ApObject, 'id'>) {
+export async function deleteBookmark(db: Database, actor: Pick<Actor, 'id'>, obj: Pick<ApObject, 'id'>) {
 	const actorId = actor.id.toString()
 	const objectId = obj.id.toString()
 
@@ -50,27 +49,17 @@ SET interaction_count = MAX(0, interaction_count - 1)
 WHERE id = ?
   AND local = 0
   AND EXISTS (SELECT 1 FROM users WHERE users.actor_id = ?)
-  AND EXISTS (SELECT 1 FROM actor_favourites WHERE actor_id = ? AND object_id = ?)
+  AND EXISTS (SELECT 1 FROM bookmarks WHERE account_id = ? AND status_id = ?)
 `
 			)
 			.bind(objectId, actorId, actorId, objectId),
-		db.prepare(`DELETE FROM actor_favourites WHERE actor_id = ? AND object_id = ?`).bind(actorId, objectId),
+		db.prepare(`DELETE FROM bookmarks WHERE account_id = ? AND status_id = ?`).bind(actorId, objectId),
 	])
 	assertBatchSuccess(results)
 	await refreshRemoteObjectInteractionCount(db, objectId)
 }
 
-export function getLikes(db: Database, obj: ApObject): Promise<Array<string>> {
-	const query = `
-		SELECT actor_id FROM actor_favourites WHERE object_id=?
-	`
-
-	const statement = db.prepare(query).bind(obj.id.toString())
-
-	return getResultsField(statement, 'actor_id')
-}
-
-export function getFavouritedObjectIds(
+export function getBookmarkedObjectIds(
 	db: Database,
 	actor: Actor,
 	{ limit, maxId }: { limit: number; maxId?: string }
@@ -78,10 +67,10 @@ export function getFavouritedObjectIds(
 	const statement = db
 		.prepare(
 			`
-SELECT object_id
-FROM actor_favourites
-INNER JOIN objects ON objects.id = actor_favourites.object_id
-WHERE actor_favourites.actor_id = ?
+SELECT status_id
+FROM bookmarks
+INNER JOIN objects ON objects.id = bookmarks.status_id
+WHERE bookmarks.account_id = ?
   AND (? IS NULL OR objects.mastodon_id < ?)
 ORDER BY objects.mastodon_id DESC
 LIMIT ?
@@ -89,5 +78,5 @@ LIMIT ?
 		)
 		.bind(actor.id.toString(), maxId ?? null, maxId ?? null, limit)
 
-	return getResultsField(statement, 'object_id')
+	return getResultsField(statement, 'status_id')
 }

--- a/packages/backend/src/mastodon/follow.ts
+++ b/packages/backend/src/mastodon/follow.ts
@@ -72,18 +72,39 @@ export async function moveFollowing(
 	}
 }
 
+export type FollowOptions = {
+	reblogs?: boolean
+	notify?: boolean
+	languages?: string[]
+}
+
 // Add a pending following
-export async function addFollowing(domain: string, db: Database, follower: Actor, followee: Actor): Promise<string> {
+export async function addFollowing(
+	domain: string,
+	db: Database,
+	follower: Pick<Actor, 'id'>,
+	followee: Pick<Actor, 'id' | 'preferredUsername'>,
+	options: FollowOptions = {}
+): Promise<string> {
 	const id = crypto.randomUUID()
 
 	const query = db.qb.insertOrIgnore(`
-		INTO actor_following (id, actor_id, target_actor_id, state, target_actor_acct)
-		VALUES (?, ?, ?, ?, ?)
+		INTO actor_following (id, actor_id, target_actor_id, state, target_actor_acct, show_reblogs, notify, languages)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 
 	const out = await db
 		.prepare(query)
-		.bind(id, follower.id.toString(), followee.id.toString(), STATE_PENDING, actorToAcct(followee, domain))
+		.bind(
+			id,
+			follower.id.toString(),
+			followee.id.toString(),
+			STATE_PENDING,
+			actorToAcct(followee, domain),
+			(options.reblogs ?? true) ? 1 : 0,
+			(options.notify ?? false) ? 1 : 0,
+			options.languages ? JSON.stringify(options.languages) : null
+		)
 		.run()
 	if (!out.success) {
 		throw new Error('SQL error: ' + out.error)
@@ -92,7 +113,7 @@ export async function addFollowing(domain: string, db: Database, follower: Actor
 }
 
 // Accept the pending following request
-export async function acceptFollowing(db: Database, follower: Actor, followee: Actor) {
+export async function acceptFollowing(db: Database, follower: Pick<Actor, 'id'>, followee: Pick<Actor, 'id'>) {
 	const followerId = follower.id.toString()
 	const followeeId = followee.id.toString()
 
@@ -122,7 +143,7 @@ UPDATE actor_following SET state=?1 WHERE actor_id=?2 AND target_actor_id=?3 AND
 	assertBatchSuccess(results)
 }
 
-export async function removeFollowing(db: Database, follower: Actor, followee: Actor) {
+export async function removeFollowing(db: Database, follower: Pick<Actor, 'id'>, followee: Pick<Actor, 'id'>) {
 	const followerId = follower.id.toString()
 	const followeeId = followee.id.toString()
 
@@ -152,22 +173,91 @@ DELETE FROM actor_following WHERE actor_id=?1 AND target_actor_id=?2
 	assertBatchSuccess(results)
 }
 
-export function getFollowingMastodonIds(db: Database, actor: Actor): Promise<MastodonId[]> {
-	return getFollowingMastodonIdsByState(db, actor, STATE_ACCEPTED)
+export type FollowingRelationship = {
+	mastodon_id: MastodonId
+	show_reblogs: number
+	notify: number
+	languages: string | null
 }
 
-export function getFollowingRequestedMastodonIds(db: Database, actor: Actor): Promise<MastodonId[]> {
-	return getFollowingMastodonIdsByState(db, actor, STATE_PENDING)
+export function getFollowingRequestedMastodonIdsForTargets(
+	db: Database,
+	actor: Actor,
+	targetIds: MastodonId[]
+): Promise<MastodonId[]> {
+	return getFollowingMastodonIdsByStateForTargets(db, actor, STATE_PENDING, targetIds)
 }
 
-function getFollowingMastodonIdsByState(db: Database, actor: Actor, state: string): Promise<MastodonId[]> {
+export async function getFollowingRelationshipsForTargets(
+	db: Database,
+	actor: Actor,
+	targetIds: MastodonId[]
+): Promise<FollowingRelationship[]> {
+	if (targetIds.length === 0) {
+		return []
+	}
+
+	const placeholders = targetIds.map(() => '?').join(', ')
+	const { success, error, results } = await db
+		.prepare(
+			`
+SELECT actors.mastodon_id, actor_following.show_reblogs, actor_following.notify, actor_following.languages
+FROM actor_following
+INNER JOIN actors ON actors.id = actor_following.target_actor_id
+WHERE actor_following.actor_id = ?
+  AND actor_following.state = ?
+  AND actors.mastodon_id IN (${placeholders})
+`
+		)
+		.bind(actor.id.toString(), STATE_ACCEPTED, ...targetIds)
+		.all<FollowingRelationship>()
+	if (!success) {
+		throw new Error('SQL error: ' + error)
+	}
+	return results ?? []
+}
+
+export function getFollowerMastodonIdsForTargets(
+	db: Database,
+	actor: Actor,
+	targetIds: MastodonId[]
+): Promise<MastodonId[]> {
+	if (targetIds.length === 0) {
+		return Promise.resolve([])
+	}
+
+	const placeholders = targetIds.map(() => '?').join(', ')
+	const query = `
+SELECT actors.mastodon_id
+FROM actor_following
+INNER JOIN actors ON actors.id = actor_following.actor_id
+WHERE actor_following.target_actor_id = ?
+  AND actor_following.state = ?
+  AND actors.mastodon_id IN (${placeholders})
+`
+	return getResultsField(db.prepare(query).bind(actor.id.toString(), STATE_ACCEPTED, ...targetIds), 'mastodon_id')
+}
+
+function getFollowingMastodonIdsByStateForTargets(
+	db: Database,
+	actor: Actor,
+	state: string,
+	targetIds: MastodonId[]
+): Promise<MastodonId[]> {
+	if (targetIds.length === 0) {
+		return Promise.resolve([])
+	}
+
+	const placeholders = targetIds.map(() => '?').join(', ')
 	const query = `
 SELECT actors.mastodon_id
 FROM actor_following
 INNER JOIN actors ON actors.id = actor_following.target_actor_id
-WHERE actor_following.actor_id=?1 AND actor_following.state=?2
+WHERE actor_following.actor_id = ?
+  AND actor_following.state = ?
+  AND actors.mastodon_id IN (${placeholders})
 `
-	return getResultsField(db.prepare(query).bind(actor.id.toString(), state), 'mastodon_id')
+	return getResultsField(db.prepare(query).bind(actor.id.toString(), state, ...targetIds), 'mastodon_id')
 }
 
 export function getFollowingId(db: Database, actor: Actor, limit?: number): Promise<Array<string>> {

--- a/packages/backend/src/mastodon/follow.ts
+++ b/packages/backend/src/mastodon/follow.ts
@@ -78,6 +78,18 @@ export type FollowOptions = {
 	languages?: string[]
 }
 
+function serializeFollowOptions(options: FollowOptions): {
+	showReblogs: number
+	notify: number
+	languages: string | null
+} {
+	return {
+		showReblogs: (options.reblogs ?? true) ? 1 : 0,
+		notify: (options.notify ?? false) ? 1 : 0,
+		languages: options.languages ? JSON.stringify(options.languages) : null,
+	}
+}
+
 // Add a pending following
 export async function addFollowing(
 	domain: string,
@@ -93,6 +105,7 @@ export async function addFollowing(
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 
+	const optionValues = serializeFollowOptions(options)
 	const out = await db
 		.prepare(query)
 		.bind(
@@ -101,15 +114,55 @@ export async function addFollowing(
 			followee.id.toString(),
 			STATE_PENDING,
 			actorToAcct(followee, domain),
-			(options.reblogs ?? true) ? 1 : 0,
-			(options.notify ?? false) ? 1 : 0,
-			options.languages ? JSON.stringify(options.languages) : null
+			optionValues.showReblogs,
+			optionValues.notify,
+			optionValues.languages
 		)
 		.run()
 	if (!out.success) {
 		throw new Error('SQL error: ' + out.error)
 	}
 	return id
+}
+
+export async function updateFollowingOptions(
+	db: Database,
+	follower: Pick<Actor, 'id'>,
+	followee: Pick<Actor, 'id'>,
+	options: FollowOptions
+): Promise<void> {
+	const updates: string[] = []
+	const values: (number | string | null)[] = []
+	const optionValues = serializeFollowOptions(options)
+	if (options.reblogs !== undefined) {
+		updates.push('show_reblogs = ?')
+		values.push(optionValues.showReblogs)
+	}
+	if (options.notify !== undefined) {
+		updates.push('notify = ?')
+		values.push(optionValues.notify)
+	}
+	if (options.languages !== undefined) {
+		updates.push('languages = ?')
+		values.push(optionValues.languages)
+	}
+	if (updates.length === 0) {
+		return
+	}
+
+	const out = await db
+		.prepare(
+			`
+	UPDATE actor_following
+	SET ${updates.join(', ')}
+	WHERE actor_id = ? AND target_actor_id = ?
+	`
+		)
+		.bind(...values, follower.id.toString(), followee.id.toString())
+		.run()
+	if (!out.success) {
+		throw new Error('SQL error: ' + out.error)
+	}
 }
 
 // Accept the pending following request
@@ -299,10 +352,6 @@ export async function isFollowingOrFollowingRequested(db: Database, actor: Actor
 		})
 
 	return yes === 1
-}
-
-export async function isNotFollowing(db: Database, actor: Actor, target: Actor): Promise<boolean> {
-	return !(await isFollowing(db, actor, target))
 }
 
 export async function isFollowing(db: Database, actor: Actor, target: Actor): Promise<boolean> {

--- a/packages/backend/src/mastodon/interaction_count.test.ts
+++ b/packages/backend/src/mastodon/interaction_count.test.ts
@@ -1,5 +1,8 @@
+import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
+import { deleteBookmark, insertBookmark } from '@wildebeest/backend/mastodon/bookmark'
 import { acceptFollowing, addFollowing, removeFollowing } from '@wildebeest/backend/mastodon/follow'
-import { insertLike } from '@wildebeest/backend/mastodon/like'
+import { deleteLike, insertLike } from '@wildebeest/backend/mastodon/like'
+import { createReblog, deleteReblog } from '@wildebeest/backend/mastodon/reblog'
 import { createPublicStatus } from '@wildebeest/backend/test/shared.utils'
 import { createTestUser, makeDB } from '@wildebeest/backend/test/utils'
 
@@ -7,6 +10,37 @@ const userKEK = 'test_kek_interaction_count'
 const domain = 'cloudflare.com'
 
 describe('interaction_count', () => {
+	async function createLocalUserAndRemoteObject(db: ReturnType<typeof makeDB>) {
+		const actorId = `https://cloudflare.com/ap/users/${crypto.randomUUID()}`
+		const objectId = `https://example.com/objects/${crypto.randomUUID()}`
+
+		await db
+			.prepare(
+				`INSERT INTO actors (id, type, username, domain, properties, mastodon_id)
+				VALUES (?, 'Person', 'local', 'cloudflare.com', '{}', ?)`
+			)
+			.bind(actorId, crypto.randomUUID())
+			.run()
+
+		await db
+			.prepare(
+				`INSERT INTO users (id, actor_id, email, privkey, privkey_salt, pubkey, is_admin, cdate)
+				VALUES (?, ?, ?, '', '', '', 0, '2020-01-01T00:00:00.000Z')`
+			)
+			.bind(crypto.randomUUID(), actorId, `${crypto.randomUUID()}@example.com`)
+			.run()
+
+		await db
+			.prepare(
+				`INSERT INTO objects (id, type, properties, local, mastodon_id)
+				VALUES (?, 'Note', '{}', 0, ?)`
+			)
+			.bind(objectId, crypto.randomUUID())
+			.run()
+
+		return { actor: { id: new URL(actorId) }, obj: { id: new URL(objectId) }, actorId, objectId }
+	}
+
 	test('favourite increments remote object interaction_count', async () => {
 		const db = makeDB()
 		const actorId = 'https://cloudflare.com/ap/users/local'
@@ -44,6 +78,200 @@ describe('interaction_count', () => {
 			.bind(objectId)
 			.first<{ interaction_count: number }>()
 		expect(row?.interaction_count).toBe(1)
+	})
+
+	test('unfavourite decrements remote object interaction_count once', async () => {
+		const db = makeDB()
+		const { actor, obj, objectId } = await createLocalUserAndRemoteObject(db)
+
+		await insertLike(db, actor, obj)
+		await deleteLike(db, actor, obj)
+		await deleteLike(db, actor, obj)
+
+		const row = await db
+			.prepare('SELECT interaction_count FROM objects WHERE id = ?')
+			.bind(objectId)
+			.first<{ interaction_count: number }>()
+		expect(row?.interaction_count).toBe(0)
+	})
+
+	test('duplicate favourite repairs remote object interaction_count', async () => {
+		const db = makeDB()
+		const { actor, obj, objectId } = await createLocalUserAndRemoteObject(db)
+
+		await insertLike(db, actor, obj)
+		await db.prepare(`UPDATE objects SET interaction_count = 5 WHERE id = ?`).bind(objectId).run()
+		await insertLike(db, actor, obj)
+
+		const row = await db
+			.prepare('SELECT interaction_count FROM objects WHERE id = ?')
+			.bind(objectId)
+			.first<{ interaction_count: number }>()
+		expect(row?.interaction_count).toBe(1)
+	})
+
+	test('duplicate unfavourite repairs remote object interaction_count', async () => {
+		const db = makeDB()
+		const { actor, obj, objectId } = await createLocalUserAndRemoteObject(db)
+
+		await insertLike(db, actor, obj)
+		await deleteLike(db, actor, obj)
+		await db.prepare(`UPDATE objects SET interaction_count = 5 WHERE id = ?`).bind(objectId).run()
+		await deleteLike(db, actor, obj)
+
+		const row = await db
+			.prepare('SELECT interaction_count FROM objects WHERE id = ?')
+			.bind(objectId)
+			.first<{ interaction_count: number }>()
+		expect(row?.interaction_count).toBe(0)
+	})
+
+	test('bookmark increments and unbookmark decrements remote object interaction_count once', async () => {
+		const db = makeDB()
+		const { actor, obj, objectId } = await createLocalUserAndRemoteObject(db)
+
+		await insertBookmark(db, actor, obj)
+		await insertBookmark(db, actor, obj)
+		await deleteBookmark(db, actor, obj)
+		await deleteBookmark(db, actor, obj)
+
+		const row = await db
+			.prepare('SELECT interaction_count FROM objects WHERE id = ?')
+			.bind(objectId)
+			.first<{ interaction_count: number }>()
+		expect(row?.interaction_count).toBe(0)
+	})
+
+	test('duplicate bookmark repairs remote object interaction_count', async () => {
+		const db = makeDB()
+		const { actor, obj, objectId } = await createLocalUserAndRemoteObject(db)
+
+		await insertBookmark(db, actor, obj)
+		await db.prepare(`UPDATE objects SET interaction_count = 5 WHERE id = ?`).bind(objectId).run()
+		await insertBookmark(db, actor, obj)
+
+		const row = await db
+			.prepare('SELECT interaction_count FROM objects WHERE id = ?')
+			.bind(objectId)
+			.first<{ interaction_count: number }>()
+		expect(row?.interaction_count).toBe(1)
+	})
+
+	test('duplicate unbookmark repairs remote object interaction_count', async () => {
+		const db = makeDB()
+		const { actor, obj, objectId } = await createLocalUserAndRemoteObject(db)
+
+		await insertBookmark(db, actor, obj)
+		await deleteBookmark(db, actor, obj)
+		await db.prepare(`UPDATE objects SET interaction_count = 5 WHERE id = ?`).bind(objectId).run()
+		await deleteBookmark(db, actor, obj)
+
+		const row = await db
+			.prepare('SELECT interaction_count FROM objects WHERE id = ?')
+			.bind(objectId)
+			.first<{ interaction_count: number }>()
+		expect(row?.interaction_count).toBe(0)
+	})
+
+	test('unreblog decrements remote object interaction_count once', async () => {
+		const db = makeDB()
+		const { actor, obj, actorId, objectId } = await createLocalUserAndRemoteObject(db)
+		const outboxObjectId = crypto.randomUUID()
+
+		await db
+			.prepare(`INSERT INTO outbox_objects (id, actor_id, object_id) VALUES (?, ?, ?)`)
+			.bind(outboxObjectId, actorId, objectId)
+			.run()
+
+		await db
+			.prepare(
+				`INSERT INTO actor_reblogs (id, actor_id, object_id, outbox_object_id, mastodon_id)
+				VALUES (?, ?, ?, ?, ?)`
+			)
+			.bind(crypto.randomUUID(), actorId, objectId, outboxObjectId, crypto.randomUUID())
+			.run()
+		await db.prepare(`UPDATE objects SET interaction_count = 1, reblogs_count = 1 WHERE id = ?`).bind(objectId).run()
+
+		await deleteReblog(db, actor, obj)
+		await deleteReblog(db, actor, obj)
+
+		const row = await db
+			.prepare('SELECT interaction_count, reblogs_count FROM objects WHERE id = ?')
+			.bind(objectId)
+			.first<{ interaction_count: number; reblogs_count: number }>()
+		expect(row?.interaction_count).toBe(0)
+		expect(row?.reblogs_count).toBe(0)
+	})
+
+	test('unreblog repairs stale remote object counters', async () => {
+		const db = makeDB()
+		const { actor, obj, actorId, objectId } = await createLocalUserAndRemoteObject(db)
+		const outboxObjectId = crypto.randomUUID()
+
+		await db
+			.prepare(`INSERT INTO outbox_objects (id, actor_id, object_id) VALUES (?, ?, ?)`)
+			.bind(outboxObjectId, actorId, objectId)
+			.run()
+		await db
+			.prepare(
+				`INSERT INTO actor_reblogs (id, actor_id, object_id, outbox_object_id, mastodon_id)
+				VALUES (?, ?, ?, ?, ?)`
+			)
+			.bind(crypto.randomUUID(), actorId, objectId, outboxObjectId, crypto.randomUUID())
+			.run()
+		await db.prepare(`UPDATE objects SET interaction_count = 5, reblogs_count = 5 WHERE id = ?`).bind(objectId).run()
+
+		await deleteReblog(db, actor, obj)
+
+		const row = await db
+			.prepare('SELECT interaction_count, reblogs_count FROM objects WHERE id = ?')
+			.bind(objectId)
+			.first<{ interaction_count: number; reblogs_count: number }>()
+		expect(row?.interaction_count).toBe(0)
+		expect(row?.reblogs_count).toBe(0)
+	})
+
+	test('duplicate reblog repairs remote object counters', async () => {
+		const db = makeDB()
+		const { actor, obj, actorId, objectId } = await createLocalUserAndRemoteObject(db)
+		const outboxObjectId = crypto.randomUUID()
+		const activityId = `https://${domain}/ap/a/${crypto.randomUUID()}`
+
+		await db
+			.prepare(`INSERT INTO outbox_objects (id, actor_id, object_id) VALUES (?, ?, ?)`)
+			.bind(outboxObjectId, actorId, objectId)
+			.run()
+		await db
+			.prepare(
+				`INSERT INTO actor_reblogs (id, actor_id, object_id, outbox_object_id, mastodon_id)
+				VALUES (?, ?, ?, ?, ?)`
+			)
+			.bind(activityId, actorId, objectId, outboxObjectId, crypto.randomUUID())
+			.run()
+
+		const created = await createReblog(
+			db,
+			actor as Parameters<typeof createReblog>[1],
+			{
+				...obj,
+				type: 'Note',
+				content: 'remote status',
+				attributedTo: new URL(actorId),
+				attachment: [],
+				sensitive: false,
+				to: [PUBLIC_GROUP],
+				cc: [],
+			},
+			{ id: new URL(activityId), to: [PUBLIC_GROUP], cc: [] }
+		)
+		expect(created).toBe(false)
+
+		const row = await db
+			.prepare('SELECT interaction_count, reblogs_count FROM objects WHERE id = ?')
+			.bind(objectId)
+			.first<{ interaction_count: number; reblogs_count: number }>()
+		expect(row?.interaction_count).toBe(1)
+		expect(row?.reblogs_count).toBe(1)
 	})
 
 	test('favourite does not increment local object interaction_count', async () => {

--- a/packages/backend/src/mastodon/mute.ts
+++ b/packages/backend/src/mastodon/mute.ts
@@ -1,0 +1,58 @@
+import type { Actor } from '@wildebeest/backend/activitypub/actors'
+import { type Database } from '@wildebeest/backend/database'
+import type { MastodonId } from '@wildebeest/backend/types'
+
+import { deleteAccountRelationship, getTargetMastodonIds, insertAccountRelationship } from './account_relationship'
+
+export async function insertMute(db: Database, actor: Actor, target: Actor, hideNotifications = true) {
+	await insertAccountRelationship(db, 'mutes', actor, target, { hideNotifications })
+}
+
+export async function deleteMute(db: Database, actor: Actor, target: Actor) {
+	await deleteAccountRelationship(db, 'mutes', actor, target)
+}
+
+export function getMutedMastodonIds(
+	db: Database,
+	actor: Actor,
+	options: { limit: number; maxId?: MastodonId; targetIds?: MastodonId[] } = { limit: 40 }
+): Promise<MastodonId[]> {
+	return getTargetMastodonIds(db, 'mutes', actor, options)
+}
+
+export type MutedMastodonRelationship = {
+	mastodon_id: MastodonId
+	hide_notifications: number
+}
+
+export async function getMutedMastodonRelationships(
+	db: Database,
+	actor: Actor,
+	{ limit, maxId, targetIds }: { limit: number; maxId?: MastodonId; targetIds?: MastodonId[] } = { limit: 40 }
+): Promise<MutedMastodonRelationship[]> {
+	if (targetIds?.length === 0) {
+		return []
+	}
+
+	const targetFilter = targetIds ? `AND actors.mastodon_id IN (${targetIds.map(() => '?').join(', ')})` : ''
+	const statement = db
+		.prepare(
+			`
+SELECT actors.mastodon_id, mutes.hide_notifications
+FROM mutes
+INNER JOIN actors ON actors.id = mutes.target_account_id
+WHERE mutes.account_id = ?
+  AND (? IS NULL OR actors.mastodon_id < ?)
+  ${targetFilter}
+ORDER BY actors.mastodon_id DESC
+LIMIT ?
+`
+		)
+		.bind(actor.id.toString(), maxId ?? null, maxId ?? null, ...(targetIds ?? []), limit)
+
+	const { success, error, results } = await statement.all<MutedMastodonRelationship>()
+	if (!success) {
+		throw new Error('SQL error: ' + error)
+	}
+	return results ?? []
+}

--- a/packages/backend/src/mastodon/reblog.ts
+++ b/packages/backend/src/mastodon/reblog.ts
@@ -3,13 +3,14 @@
 import { AnnounceActivity, PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import type { Actor } from '@wildebeest/backend/activitypub/actors'
 import { addObjectInOutbox } from '@wildebeest/backend/activitypub/actors/outbox'
-import { getApId } from '@wildebeest/backend/activitypub/objects'
+import { getApId, originalObjectIdSymbol } from '@wildebeest/backend/activitypub/objects'
 import { Note } from '@wildebeest/backend/activitypub/objects/note'
 import { type Database } from '@wildebeest/backend/database'
 import { MastodonId } from '@wildebeest/backend/types'
 import { isUUID } from '@wildebeest/backend/utils'
 import { generateMastodonId } from '@wildebeest/backend/utils/id'
 
+import { refreshReblogAndRemoteInteractionCounts } from './interaction_count'
 import { assertBatchSuccess, getResultsField } from './utils'
 
 /**
@@ -25,12 +26,20 @@ export async function createReblog(
 	obj: Note,
 	activity: Pick<AnnounceActivity, 'id' | 'to' | 'cc'>,
 	published?: string
-) {
+): Promise<boolean> {
 	const [outboxObjectId, mastodonId] = await Promise.all([
 		addObjectInOutbox(db, actor, obj, activity.to ?? obj.to, activity.cc ?? obj.cc, published),
 		generateMastodonId(db, 'actor_reblogs', new Date()),
 	])
-	await insertReblog(db, actor, obj, activity.id.toString(), outboxObjectId, mastodonId)
+	const inserted = await insertReblog(db, actor, obj, activity.id.toString(), outboxObjectId, mastodonId)
+	if (!inserted) {
+		const results = await db.batch([
+			db.prepare(`DELETE FROM outbox_objects WHERE id = ?`).bind(outboxObjectId),
+			db.prepare(`DELETE FROM actor_activities WHERE json_extract(activity, '$.id') = ?`).bind(activity.id.toString()),
+		])
+		assertBatchSuccess(results)
+	}
+	return inserted
 }
 
 async function insertReblog(
@@ -40,30 +49,23 @@ async function insertReblog(
 	activityId: string,
 	outboxObjectId: string,
 	mastodonId: MastodonId
-) {
-	const results = await db.batch([
-		db
-			.prepare(
-				db.qb.insertOrIgnore(`
+): Promise<boolean> {
+	const actorId = actor.id.toString()
+	const objectId = obj.id.toString()
+	const insert = await db
+		.prepare(
+			db.qb.insertOrIgnore(`
 INTO actor_reblogs (id, actor_id, object_id, outbox_object_id, mastodon_id)
 VALUES (?, ?, ?, ?, ?)
 `)
-			)
-			.bind(activityId, actor.id.toString(), obj.id.toString(), outboxObjectId, mastodonId),
-		db
-			.prepare(
-				`
-UPDATE objects
-SET interaction_count = interaction_count + 1
-WHERE id = ?
-  AND local = 0
-  AND EXISTS (SELECT 1 FROM users WHERE users.actor_id = ?)
-  AND EXISTS (SELECT 1 FROM actor_reblogs WHERE id = ?)
-`
-			)
-			.bind(obj.id.toString(), actor.id.toString(), activityId),
-	])
-	assertBatchSuccess(results)
+		)
+		.bind(activityId, actorId, objectId, outboxObjectId, mastodonId)
+		.run()
+	if (!insert.success) {
+		throw new Error('SQL error: ' + insert.error)
+	}
+	await refreshReblogAndRemoteInteractionCounts(db, objectId)
+	return insert.meta.changes === 1
 }
 
 export function getReblogs(db: Database, obj: Note): Promise<Array<string>> {
@@ -74,6 +76,75 @@ export function getReblogs(db: Database, obj: Note): Promise<Array<string>> {
 	const statement = db.prepare(query).bind(obj.id.toString())
 
 	return getResultsField(statement, 'actor_id')
+}
+
+export async function getReblogActivity(
+	db: Database,
+	actor: Pick<Actor, 'id'>,
+	obj: Note
+): Promise<AnnounceActivity | null> {
+	const row = await db
+		.prepare(
+			`
+SELECT actor_reblogs.id, outbox_objects.published_date, outbox_objects.'to', outbox_objects.cc
+FROM actor_reblogs
+LEFT JOIN outbox_objects ON outbox_objects.id = actor_reblogs.outbox_object_id
+WHERE actor_reblogs.actor_id = ? AND actor_reblogs.object_id = ?
+`
+		)
+		.bind(actor.id.toString(), obj.id.toString())
+		.first<{ id: string; published_date: string | null; to: string | null; cc: string | null }>()
+
+	if (!row) {
+		return null
+	}
+
+	return {
+		'@context': 'https://www.w3.org/ns/activitystreams',
+		id: row.id,
+		type: 'Announce',
+		actor: actor.id,
+		object: new URL(obj[originalObjectIdSymbol] ?? obj.id.toString()),
+		to: JSON.parse(row.to ?? '[]'),
+		cc: JSON.parse(row.cc ?? '[]'),
+		...(row.published_date ? { published: row.published_date } : {}),
+	}
+}
+
+export async function deleteReblog(db: Database, actor: Pick<Actor, 'id'>, obj: Pick<Note, 'id'>): Promise<boolean> {
+	return deleteReblogWhere(db, actor.id.toString(), 'object_id = ?', obj.id.toString())
+}
+
+export async function deleteReblogByActivityId(
+	db: Database,
+	actor: Pick<Actor, 'id'>,
+	activityId: URL
+): Promise<boolean> {
+	return deleteReblogWhere(db, actor.id.toString(), 'id = ?', activityId.toString())
+}
+
+async function deleteReblogWhere(db: Database, actorId: string, condition: string, value: string): Promise<boolean> {
+	const row = await db
+		.prepare(`SELECT object_id FROM actor_reblogs WHERE actor_id = ? AND ${condition}`)
+		.bind(actorId, value)
+		.first<{ object_id: string }>()
+	if (!row) {
+		return false
+	}
+
+	const objectId = row.object_id
+	const results = await db.batch([
+		db
+			.prepare(
+				`DELETE FROM outbox_objects
+WHERE id = (SELECT outbox_object_id FROM actor_reblogs WHERE actor_id = ? AND ${condition})`
+			)
+			.bind(actorId, value),
+		db.prepare(`DELETE FROM actor_reblogs WHERE actor_id = ? AND ${condition}`).bind(actorId, value),
+	])
+	assertBatchSuccess(results)
+	await refreshReblogAndRemoteInteractionCounts(db, objectId)
+	return true
 }
 
 export async function hasReblog(db: Database, actor: Actor, obj: Note): Promise<boolean> {

--- a/packages/backend/src/mastodon/relationship.ts
+++ b/packages/backend/src/mastodon/relationship.ts
@@ -1,0 +1,70 @@
+import type { Actor } from '@wildebeest/backend/activitypub/actors'
+import type { Database } from '@wildebeest/backend/database'
+import type { MastodonId } from '@wildebeest/backend/types'
+import type { Relationship } from '@wildebeest/backend/types/account'
+
+import { getBlockedByMastodonIds, getBlockedMastodonIds } from './block'
+import {
+	getFollowerMastodonIdsForTargets,
+	getFollowingRelationshipsForTargets,
+	getFollowingRequestedMastodonIdsForTargets,
+} from './follow'
+import { getMutedMastodonRelationships } from './mute'
+
+export function makeRelationship(id: MastodonId, overrides: Partial<Omit<Relationship, 'id'>> = {}): Relationship {
+	return {
+		id,
+		following: false,
+		showing_reblogs: false,
+		notifying: false,
+		followed_by: false,
+		blocking: false,
+		blocked_by: false,
+		muting: false,
+		muting_notifications: false,
+		requested: false,
+		domain_blocking: false,
+		endorsed: false,
+		note: '',
+		...overrides,
+	}
+}
+
+export async function getRelationships(db: Database, actor: Actor, ids: MastodonId[]): Promise<Relationship[]> {
+	const [following, followedBy, followingRequested, blocking, blockedBy, muting] = await Promise.all([
+		getFollowingRelationshipsForTargets(db, actor, ids),
+		getFollowerMastodonIdsForTargets(db, actor, ids),
+		getFollowingRequestedMastodonIdsForTargets(db, actor, ids),
+		getBlockedMastodonIds(db, actor, { limit: ids.length, targetIds: ids }),
+		getBlockedByMastodonIds(db, actor, ids),
+		getMutedMastodonRelationships(db, actor, { limit: ids.length, targetIds: ids }),
+	])
+
+	const followingMap = new Map(following.map((follow) => [follow.mastodon_id, follow]))
+	const followedBySet = new Set(followedBy)
+	const followingRequestedSet = new Set(followingRequested)
+	const blockingSet = new Set(blocking)
+	const blockedBySet = new Set(blockedBy)
+	const mutingMap = new Map(muting.map((mute) => [mute.mastodon_id, mute.hide_notifications !== 0]))
+
+	return ids.map((id) => {
+		const follow = followingMap.get(id)
+		return makeRelationship(id, {
+			following: follow !== undefined,
+			showing_reblogs: follow ? follow.show_reblogs !== 0 : false,
+			notifying: follow?.notify === 1,
+			languages: follow?.languages ? JSON.parse(follow.languages) : undefined,
+			followed_by: followedBySet.has(id),
+			requested: followingRequestedSet.has(id),
+			blocking: blockingSet.has(id),
+			blocked_by: blockedBySet.has(id),
+			muting: mutingMap.has(id),
+			muting_notifications: mutingMap.get(id) ?? false,
+		})
+	})
+}
+
+export async function getRelationship(db: Database, actor: Actor, id: MastodonId): Promise<Relationship> {
+	const [relationship] = await getRelationships(db, actor, [id])
+	return relationship
+}

--- a/packages/backend/src/mastodon/status.ts
+++ b/packages/backend/src/mastodon/status.ts
@@ -605,7 +605,7 @@ export async function toMastodonStatusFromRow(
 				language: null,
 				text: null,
 				muted: false,
-				bookmarked: false,
+				bookmarked: row.bookmarked === 1,
 				pinned: false,
 				// filtered
 			},

--- a/packages/backend/src/mastodon/status.ts
+++ b/packages/backend/src/mastodon/status.ts
@@ -1,5 +1,4 @@
 import { getUserId, isLocalAccount } from '@wildebeest/backend/accounts'
-import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import {
 	type Actor,
 	actorFromRow,
@@ -21,20 +20,15 @@ import { isNote, type Note } from '@wildebeest/backend/activitypub/objects/note'
 import { type Database } from '@wildebeest/backend/database'
 import { selectObjectRevisionsByObjectID } from '@wildebeest/backend/database/d1/querier'
 import { loadMastodonAccount } from '@wildebeest/backend/mastodon/account'
-import { isFollowing } from '@wildebeest/backend/mastodon/follow'
 import { ensureReblogMastodonId } from '@wildebeest/backend/mastodon/reblog'
+import { detectVisibility } from '@wildebeest/backend/mastodon/status_visibility'
 import * as media from '@wildebeest/backend/media/'
-import type {
-	MastodonAccount,
-	MastodonId,
-	MastodonStatus,
-	MastodonStatusEdit,
-	Visibility,
-} from '@wildebeest/backend/types'
+import type { MastodonAccount, MastodonId, MastodonStatus, MastodonStatusEdit } from '@wildebeest/backend/types'
 import type { MediaAttachment } from '@wildebeest/backend/types/media'
-import { toArray } from '@wildebeest/backend/utils'
 import { actorToAcct, actorToHandle, handleToAcct, parseHandle } from '@wildebeest/backend/utils/handle'
 import { queryAcct } from '@wildebeest/backend/webfinger'
+
+export { canViewStatus, detectVisibility, isVisible } from '@wildebeest/backend/mastodon/status_visibility'
 
 export const MAX_STATUS_LENGTH = 500
 export const MAX_MEDIA_ATTACHMENTS = 4
@@ -81,6 +75,32 @@ export function actorToMention(domain: string, actor: Actor): MastodonStatus['me
 	}
 }
 
+export async function setMastodonStatusViewerState(
+	db: Database,
+	status: MastodonStatus,
+	obj: Pick<Note, 'id'>,
+	actor: Pick<Actor, 'id'>
+): Promise<MastodonStatus> {
+	const actorId = actor.id.toString()
+	const objectId = obj.id.toString()
+	const row = await db
+		.prepare(
+			`
+SELECT
+  (SELECT count(*) > 0 FROM actor_favourites WHERE actor_id = ? AND object_id = ?) as favourited,
+  (SELECT count(*) > 0 FROM actor_reblogs WHERE actor_id = ? AND object_id = ?) as reblogged,
+  (SELECT count(*) > 0 FROM bookmarks WHERE account_id = ? AND status_id = ?) as bookmarked
+`
+		)
+		.bind(actorId, objectId, actorId, objectId, actorId, objectId)
+		.first<{ favourited: 1 | 0; reblogged: 1 | 0; bookmarked: 1 | 0 }>()
+
+	status.favourited = row?.favourited === 1
+	status.reblogged = row?.reblogged === 1
+	status.bookmarked = row?.bookmarked === 1
+	return status
+}
+
 export async function toMastodonStatusFromObject(
 	db: Database,
 	obj: RemoteObject<Note>,
@@ -100,11 +120,19 @@ export async function toMastodonStatusFromObject(
 	}
 	const handle = actorToHandle(actor)
 
-	// FIXME: temporarily disable favourites and reblogs counts
-	const favourites = []
-	const reblogs = []
-	// const favourites = await getLikes(db, obj)
-	// const reblogs = await getReblogs(db, obj)
+	const counts = await db
+		.prepare(
+			`
+SELECT
+  (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id = objects.id) as favourites_count,
+  COALESCE(reblogs_count, 0) as reblogs_count,
+  COALESCE(replies_count, 0) as replies_count
+FROM objects
+WHERE id = ?
+`
+		)
+		.bind(obj.id.toString())
+		.first<{ favourites_count: number; reblogs_count: number; replies_count: number }>()
 
 	const mediaAttachments: Array<MediaAttachment> = obj.attachment
 		? obj.attachment.map((doc) => media.fromObject(doc))
@@ -167,9 +195,9 @@ export async function toMastodonStatusFromObject(
 		tags: [],
 		in_reply_to_id: inReplyToId,
 		in_reply_to_account_id: inReplyToAccountId,
-		reblogs_count: reblogs.length,
-		favourites_count: favourites.length,
-		replies_count: 0,
+		reblogs_count: counts?.reblogs_count ?? 0,
+		favourites_count: counts?.favourites_count ?? 0,
+		replies_count: counts?.replies_count ?? 0,
 		favourited: false,
 		reblogged: false,
 		poll: null,
@@ -203,6 +231,7 @@ type MastodonStatusRow = {
 	properties: string | object
 	reblogged?: 1 | 0
 	favourited?: 1 | 0
+	bookmarked?: 1 | 0
 
 	publisher_actor_id?: string
 	publisher_published?: string
@@ -381,7 +410,7 @@ export async function toMastodonStatusesFromRowsWithActor(
 					language: null,
 					text: null,
 					muted: false,
-					bookmarked: false,
+					bookmarked: row.bookmarked === 1,
 					pinned: false,
 					// filtered
 				},
@@ -426,7 +455,7 @@ export async function toMastodonStatusesFromRowsWithActor(
 				language: null,
 				text: null,
 				muted: false,
-				bookmarked: false,
+				bookmarked: row.bookmarked === 1,
 				pinned: false,
 				// filtered
 			}
@@ -621,7 +650,7 @@ export async function toMastodonStatusFromRow(
 			language: null,
 			text: null,
 			muted: false,
-			bookmarked: false,
+			bookmarked: row.bookmarked === 1,
 			pinned: false,
 			// filtered
 		}
@@ -640,41 +669,6 @@ export async function getMastodonStatusById(
 		return null
 	}
 	return toMastodonStatusFromObject(db, obj, domain)
-}
-
-export function detectVisibility({
-	to,
-	cc,
-	followers,
-}: Pick<Note, 'to' | 'cc'> & Pick<Actor, 'followers'>): Visibility {
-	to = Array.isArray(to) ? to : [to]
-	cc = Array.isArray(cc) ? cc : [cc]
-
-	if (to.includes(PUBLIC_GROUP)) {
-		return 'public'
-	}
-	if (to.includes(followers.toString())) {
-		if (cc.includes(PUBLIC_GROUP)) {
-			return 'unlisted'
-		}
-		return 'private'
-	}
-	return 'direct'
-}
-
-export async function isVisible(db: Database, author: Actor, viewer: Actor | undefined, note: Note): Promise<boolean> {
-	const visibility = detectVisibility({ to: note.to, cc: note.cc, followers: author.followers })
-	if (visibility === 'public' || visibility === 'unlisted') {
-		return true
-	}
-	if (!viewer) {
-		throw new Error('viewer is required')
-	}
-	if (visibility === 'private') {
-		return isFollowing(db, viewer, author)
-	}
-	const viewerId = getApId(viewer.id).toString()
-	return toArray(note.to).some((target) => getApId(target).toString() === viewerId)
 }
 
 export async function getStatusRevisions(

--- a/packages/backend/src/mastodon/status_response.ts
+++ b/packages/backend/src/mastodon/status_response.ts
@@ -1,0 +1,51 @@
+import type { Actor } from '@wildebeest/backend/activitypub/actors'
+import { getObjectById, getObjectByMastodonId, type RemoteObject } from '@wildebeest/backend/activitypub/objects'
+import type { Note } from '@wildebeest/backend/activitypub/objects/note'
+import type { Database } from '@wildebeest/backend/database'
+import { setMastodonStatusViewerState, toMastodonStatusFromObject } from '@wildebeest/backend/mastodon/status'
+import { canViewStatus } from '@wildebeest/backend/mastodon/status_visibility'
+import type { MastodonId, MastodonStatus } from '@wildebeest/backend/types'
+
+export async function loadVisibleStatusObject(
+	db: Database,
+	domain: string,
+	id: MastodonId,
+	viewer: Actor | undefined
+): Promise<RemoteObject<Note> | null> {
+	const obj = await getObjectByMastodonId<Note>(domain, db, id)
+	if (obj === null) {
+		return null
+	}
+	return (await canViewStatus(db, obj, viewer)) ? obj : null
+}
+
+export async function toViewerStatusResponse(
+	db: Database,
+	domain: string,
+	obj: RemoteObject<Note>,
+	viewer: Actor | undefined
+): Promise<MastodonStatus | null> {
+	const status = await toMastodonStatusFromObject(db, obj, domain)
+	if (status === null) {
+		return null
+	}
+	return viewer ? setMastodonStatusViewerState(db, status, obj, viewer) : status
+}
+
+export async function loadViewerStatusesByObjectIds(
+	db: Database,
+	domain: string,
+	objectIds: string[],
+	viewer: Actor
+): Promise<MastodonStatus[]> {
+	const statuses = await Promise.all(
+		objectIds.map(async (objectId) => {
+			const obj = await getObjectById<Note>(domain, db, objectId)
+			if (!obj) {
+				return null
+			}
+			return toViewerStatusResponse(db, domain, obj, viewer)
+		})
+	)
+	return statuses.filter((status): status is MastodonStatus => status !== null)
+}

--- a/packages/backend/src/mastodon/status_response.ts
+++ b/packages/backend/src/mastodon/status_response.ts
@@ -1,6 +1,6 @@
 import type { Actor } from '@wildebeest/backend/activitypub/actors'
 import { getObjectById, getObjectByMastodonId, type RemoteObject } from '@wildebeest/backend/activitypub/objects'
-import type { Note } from '@wildebeest/backend/activitypub/objects/note'
+import { isNote, type Note } from '@wildebeest/backend/activitypub/objects/note'
 import type { Database } from '@wildebeest/backend/database'
 import { setMastodonStatusViewerState, toMastodonStatusFromObject } from '@wildebeest/backend/mastodon/status'
 import { canViewStatus } from '@wildebeest/backend/mastodon/status_visibility'
@@ -13,7 +13,7 @@ export async function loadVisibleStatusObject(
 	viewer: Actor | undefined
 ): Promise<RemoteObject<Note> | null> {
 	const obj = await getObjectByMastodonId<Note>(domain, db, id)
-	if (obj === null) {
+	if (obj === null || !isNote(obj)) {
 		return null
 	}
 	return (await canViewStatus(db, obj, viewer)) ? obj : null
@@ -42,6 +42,9 @@ export async function loadViewerStatusesByObjectIds(
 		objectIds.map(async (objectId) => {
 			const obj = await getObjectById<Note>(domain, db, objectId)
 			if (!obj) {
+				return null
+			}
+			if (!isNote(obj) || !(await canViewStatus(db, obj, viewer))) {
 				return null
 			}
 			return toViewerStatusResponse(db, domain, obj, viewer)

--- a/packages/backend/src/mastodon/status_visibility.test.ts
+++ b/packages/backend/src/mastodon/status_visibility.test.ts
@@ -31,5 +31,13 @@ describe('mastodon/status_visibility', () => {
 			}),
 			'private'
 		)
+		assert.equal(
+			detectVisibility({
+				to: [new URL('https://example.com/users/bob')],
+				cc: [],
+				followers,
+			}),
+			'direct'
+		)
 	})
 })

--- a/packages/backend/src/mastodon/status_visibility.test.ts
+++ b/packages/backend/src/mastodon/status_visibility.test.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from 'node:assert/strict'
+
+import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
+import { detectVisibility } from '@wildebeest/backend/mastodon/status_visibility'
+
+describe('mastodon/status_visibility', () => {
+	test('detects visibility from URL and object recipients', () => {
+		const followers = new URL('https://example.com/users/alice/followers')
+
+		assert.equal(
+			detectVisibility({
+				to: [new URL(PUBLIC_GROUP)],
+				cc: [],
+				followers,
+			}),
+			'public'
+		)
+		assert.equal(
+			detectVisibility({
+				to: [{ id: followers }],
+				cc: [{ id: new URL(PUBLIC_GROUP) }],
+				followers,
+			}),
+			'unlisted'
+		)
+		assert.equal(
+			detectVisibility({
+				to: [{ id: followers }],
+				cc: [],
+				followers,
+			}),
+			'private'
+		)
+	})
+})

--- a/packages/backend/src/mastodon/status_visibility.ts
+++ b/packages/backend/src/mastodon/status_visibility.ts
@@ -1,0 +1,75 @@
+import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
+import type { Actor } from '@wildebeest/backend/activitypub/actors'
+import { getAndCacheActor } from '@wildebeest/backend/activitypub/actors'
+import { getApId, originalActorIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import type { Note } from '@wildebeest/backend/activitypub/objects/note'
+import type { Database } from '@wildebeest/backend/database'
+import { hasBlockBetween } from '@wildebeest/backend/mastodon/block'
+import { isFollowing } from '@wildebeest/backend/mastodon/follow'
+import type { Visibility } from '@wildebeest/backend/types'
+import { toArray } from '@wildebeest/backend/utils'
+
+type VisibilityAddressing = Pick<Note, 'to' | 'cc'> & Pick<Actor, 'followers'>
+
+type ViewableNote = {
+	[originalActorIdSymbol]?: string
+	to?: Note['to']
+	cc?: Note['cc']
+}
+
+export function detectVisibility({ to, cc, followers }: VisibilityAddressing): Visibility {
+	to = Array.isArray(to) ? to : [to]
+	cc = Array.isArray(cc) ? cc : [cc]
+
+	if (to.includes(PUBLIC_GROUP)) {
+		return 'public'
+	}
+	if (to.includes(followers.toString())) {
+		if (cc.includes(PUBLIC_GROUP)) {
+			return 'unlisted'
+		}
+		return 'private'
+	}
+	return 'direct'
+}
+
+export async function isVisible(
+	db: Database,
+	author: Actor,
+	viewer: Actor | undefined,
+	note: { to?: Note['to']; cc?: Note['cc'] }
+): Promise<boolean> {
+	const visibility = detectVisibility({ to: note.to ?? [], cc: note.cc ?? [], followers: author.followers })
+	if (visibility === 'public' || visibility === 'unlisted') {
+		return true
+	}
+	if (!viewer) {
+		return false
+	}
+	if (viewer.id.toString() === author.id.toString()) {
+		return true
+	}
+	if (visibility === 'private') {
+		return isFollowing(db, viewer, author)
+	}
+	const viewerId = getApId(viewer.id).toString()
+	return toArray(note.to ?? []).some((target) => getApId(target).toString() === viewerId)
+}
+
+export async function canViewStatus(db: Database, note: ViewableNote, viewer: Actor | undefined): Promise<boolean> {
+	const actorId = note[originalActorIdSymbol]
+	if (!actorId) {
+		return false
+	}
+	const author = await getAndCacheActor(new URL(actorId), db).catch((err) => {
+		console.warn('failed to load status author: ' + err)
+		return null
+	})
+	if (author === null) {
+		return false
+	}
+	if (viewer && (await hasBlockBetween(db, viewer, author))) {
+		return false
+	}
+	return isVisible(db, author, viewer, note)
+}

--- a/packages/backend/src/mastodon/status_visibility.ts
+++ b/packages/backend/src/mastodon/status_visibility.ts
@@ -17,15 +17,18 @@ type ViewableNote = {
 	cc?: Note['cc']
 }
 
-export function detectVisibility({ to, cc, followers }: VisibilityAddressing): Visibility {
-	to = Array.isArray(to) ? to : [to]
-	cc = Array.isArray(cc) ? cc : [cc]
+function hasAddress(targets: Note['to'] | undefined, id: string): boolean {
+	return toArray(targets ?? []).some((target) => getApId(target).toString() === id)
+}
 
-	if (to.includes(PUBLIC_GROUP)) {
+export function detectVisibility({ to, cc, followers }: VisibilityAddressing): Visibility {
+	if (hasAddress(to, PUBLIC_GROUP)) {
 		return 'public'
 	}
-	if (to.includes(followers.toString())) {
-		if (cc.includes(PUBLIC_GROUP)) {
+
+	const followersId = followers.toString()
+	if (hasAddress(to, followersId)) {
+		if (hasAddress(cc, PUBLIC_GROUP)) {
 			return 'unlisted'
 		}
 		return 'private'
@@ -52,8 +55,7 @@ export async function isVisible(
 	if (visibility === 'private') {
 		return isFollowing(db, viewer, author)
 	}
-	const viewerId = getApId(viewer.id).toString()
-	return toArray(note.to ?? []).some((target) => getApId(target).toString() === viewerId)
+	return hasAddress(note.to, getApId(viewer.id).toString())
 }
 
 export async function canViewStatus(db: Database, note: ViewableNote, viewer: Actor | undefined): Promise<boolean> {

--- a/packages/backend/src/mastodon/timeline.test.ts
+++ b/packages/backend/src/mastodon/timeline.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert/strict'
 
 import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import { createAnnounceActivity } from '@wildebeest/backend/activitypub/activities/announce'
+import { insertBookmark } from '@wildebeest/backend/mastodon/bookmark'
 import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
 import { insertHashtags } from '@wildebeest/backend/mastodon/hashtag'
 import { insertLike } from '@wildebeest/backend/mastodon/like'
@@ -43,6 +44,7 @@ describe('mastodon/timeline', () => {
 		})
 
 		await insertLike(db, actor, firstNoteFromActor2)
+		await insertBookmark(db, actor, firstNoteFromActor2)
 		await createReblog(db, actor, firstNoteFromActor2, {
 			to: [PUBLIC_GROUP],
 			cc: [],
@@ -58,12 +60,14 @@ describe('mastodon/timeline', () => {
 		assert.equal(data[0].account.username, 'sven')
 		assert.equal(data[0].reblog?.content, '<p>first status from actor2</p>')
 		assert.equal(data[0].reblog?.account.username, 'sven2')
+		assert.equal(data[0].reblog?.bookmarked, true)
 		assert.equal(data[1].content, '<p>second status from actor2</p>')
 		assert.equal(data[1].account.username, 'sven2')
 		assert.equal(data[2].content, '<p>first status from actor2</p>')
 		assert.equal(data[2].account.username, 'sven2')
 		assert.equal(data[2].favourites_count, 1)
 		assert.equal(data[2].reblogs_count, 1)
+		assert.equal(data[2].bookmarked, true)
 	})
 
 	test("home doesn't show private Notes from followed actors", async () => {

--- a/packages/backend/src/mastodon/timeline.ts
+++ b/packages/backend/src/mastodon/timeline.ts
@@ -78,6 +78,7 @@ SELECT
 
   (SELECT count(*) > 0 FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id AND actor_reblogs.actor_id=?1) as reblogged,
   (SELECT count(*) > 0 FROM actor_favourites WHERE actor_favourites.object_id=objects.id AND actor_favourites.actor_id=?1) as favourited,
+  (SELECT count(*) > 0 FROM bookmarks WHERE bookmarks.status_id=objects.id AND bookmarks.account_id=?1) as bookmarked,
 
   actor_reblogs.id as reblog_id,
   actor_reblogs.mastodon_id as reblog_mastodon_id
@@ -135,6 +136,7 @@ LIMIT ?4
 
 				reblogged: 1 | 0
 				favourited: 1 | 0
+				bookmarked: 1 | 0
 			} & ({ reblog_id: string; reblog_mastodon_id: string } | { reblog_id: null; reblog_mastodon_id: null })
 		>()
 	if (!success) {
@@ -337,6 +339,7 @@ SELECT
 
   (SELECT count(*) > 0 FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id AND actor_reblogs.actor_id=?1) as reblogged,
   (SELECT count(*) > 0 FROM actor_favourites WHERE actor_favourites.object_id=objects.id AND actor_favourites.actor_id=?1) as favourited,
+  (SELECT count(*) > 0 FROM bookmarks WHERE bookmarks.status_id=objects.id AND bookmarks.account_id=?1) as bookmarked,
 
   actor_reblogs.id as reblog_id,
   actor_reblogs.mastodon_id as reblog_mastodon_id
@@ -388,6 +391,7 @@ LIMIT ?4
 
 				reblogged: 1 | 0
 				favourited: 1 | 0
+				bookmarked: 1 | 0
 			} & ({ reblog_id: string; reblog_mastodon_id: string } | { reblog_id: null; reblog_mastodon_id: null })
 		>()
 	if (!success) {

--- a/packages/backend/src/routes/api/v1/accounts/[id]/block.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/block.ts
@@ -1,0 +1,61 @@
+// https://docs.joinmastodon.org/methods/accounts/#block
+
+import { Hono } from 'hono'
+
+import { getActorByMastodonId, type Person } from '@wildebeest/backend/activitypub/actors'
+import { cacheFromEnv, type Cache } from '@wildebeest/backend/cache'
+import { type Database, getDatabase } from '@wildebeest/backend/database'
+import { notAuthorized, resourceNotFound } from '@wildebeest/backend/errors'
+import { insertBlock, isSelfBlock, removeBlockRelatedFollows } from '@wildebeest/backend/mastodon/block'
+import { getRelationship } from '@wildebeest/backend/mastodon/relationship'
+import * as timeline from '@wildebeest/backend/mastodon/timeline'
+import type { HonoEnv } from '@wildebeest/backend/types'
+import { cors } from '@wildebeest/backend/utils'
+
+const app = new Hono<HonoEnv>()
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+app.post<'/:id/block'>(async ({ req, env }) => {
+	if (!env.data.connectedActor) {
+		return notAuthorized('not authorized')
+	}
+	return handleRequest(
+		getDatabase(env),
+		env.data.connectedActor,
+		req.param('id'),
+		new URL(req.url).hostname,
+		cacheFromEnv(env)
+	)
+})
+
+async function handleRequest(
+	db: Database,
+	connectedActor: Person,
+	id: string,
+	domain: string,
+	cache: Cache
+): Promise<Response> {
+	const target = await getActorByMastodonId(db, id)
+	if (!target) {
+		return resourceNotFound('id', id)
+	}
+	if (isSelfBlock(connectedActor, target)) {
+		return new Response('', { status: 403 })
+	}
+
+	await insertBlock(db, connectedActor, target)
+	await removeBlockRelatedFollows(db, connectedActor, target)
+	await Promise.all([
+		timeline.pregenerateTimelines(domain, db, cache, connectedActor),
+		timeline.pregenerateTimelines(domain, db, cache, target),
+	])
+
+	const res = await getRelationship(db, connectedActor, id)
+	return new Response(JSON.stringify(res), { headers })
+}
+
+export default app

--- a/packages/backend/src/routes/api/v1/accounts/[id]/block.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/block.ts
@@ -52,7 +52,9 @@ async function handleRequest(
 	await Promise.all([
 		timeline.pregenerateTimelines(domain, db, cache, connectedActor),
 		timeline.pregenerateTimelines(domain, db, cache, target),
-	])
+	]).catch((err) => {
+		console.warn('failed to pregenerate timelines after block', err)
+	})
 
 	const res = await getRelationship(db, connectedActor, id)
 	return new Response(JSON.stringify(res), { headers })

--- a/packages/backend/src/routes/api/v1/accounts/[id]/follow.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/follow.test.ts
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert/strict'
 import app from '@wildebeest/backend'
 import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
 import { insertBlock } from '@wildebeest/backend/mastodon/block'
+import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
 import { makeDB, createTestUser, assertStatus, assertCORS, assertJSON } from '@wildebeest/backend/test/utils'
 import { queryAcct } from '@wildebeest/backend/webfinger'
 
@@ -126,5 +127,117 @@ describe('/api/v1/accounts/[id]/follow', () => {
 		assert.equal(row.target_actor_acct, 'actor@example.com')
 		assert.equal(row.target_actor_id, `https://example.com/ap/users/actor`)
 		assert.equal(row.state, 'pending')
+	})
+
+	test('follow keeps local state when remote delivery fails', async () => {
+		let inboxRequests = 0
+
+		globalThis.fetch = async (input: RequestInfo) => {
+			const request = new Request(input)
+			if (request.url === 'https://example.com/.well-known/webfinger?resource=acct%3Afailing%40example.com') {
+				return new Response(
+					JSON.stringify({
+						links: [
+							{
+								rel: 'self',
+								type: 'application/activity+json',
+								href: `https://example.com/ap/users/failing`,
+							},
+						],
+					})
+				)
+			}
+
+			if (request.url === `https://example.com/ap/users/failing`) {
+				return new Response(
+					JSON.stringify({
+						id: `https://example.com/ap/users/failing`,
+						type: 'Person',
+						inbox: `https://example.com/ap/users/failing/inbox`,
+						preferredUsername: 'failing',
+					})
+				)
+			}
+
+			if (request.url === `https://example.com/ap/users/failing/inbox`) {
+				inboxRequests += 1
+				return new Response('temporary failure', { status: 503 })
+			}
+
+			throw new Error('unexpected request to ' + request.url)
+		}
+
+		const db = makeDB()
+		const connectedActor = await createTestUser(domain, db, userKEK, 'delivery-failure@cloudflare.com')
+		const followee = await queryAcct({ localPart: 'failing', domain: 'example.com' }, db)
+		assert.ok(followee)
+
+		const req = new Request(`https://${domain}/api/v1/accounts/${followee[mastodonIdSymbol]}/follow`, {
+			method: 'POST',
+		})
+		const res = await app.fetch(req, { DATABASE: db, userKEK, data: { connectedActor } })
+		await assertStatus(res, 200)
+		assert.equal(inboxRequests, 1)
+
+		const row = await db
+			.prepare(`SELECT target_actor_id, state FROM actor_following WHERE actor_id=?`)
+			.bind(connectedActor.id.toString())
+			.first<{ target_actor_id: string; state: string }>()
+		assert.equal(row?.target_actor_id, `https://example.com/ap/users/failing`)
+		assert.equal(row?.state, 'pending')
+	})
+
+	test('follow updates settings for an existing relationship', async () => {
+		globalThis.fetch = async (input: RequestInfo) => {
+			const request = new Request(input)
+			throw new Error('unexpected request to ' + request.url)
+		}
+
+		const db = makeDB()
+		const connectedActor = await createTestUser(domain, db, userKEK, 'follow-settings@cloudflare.com')
+		const followee = {
+			id: new URL('https://example.com/ap/users/settings'),
+			type: 'Person',
+			inbox: new URL('https://example.com/ap/users/settings/inbox'),
+			preferredUsername: 'settings',
+			mastodonId: 'settings-remote',
+		}
+		await db
+			.prepare(
+				`INSERT INTO actors (id, type, username, domain, properties, mastodon_id) VALUES (?, 'Person', 'settings', 'example.com', ?, ?)`
+			)
+			.bind(
+				followee.id.toString(),
+				JSON.stringify({
+					id: followee.id.toString(),
+					type: 'Person',
+					inbox: followee.inbox.toString(),
+					preferredUsername: followee.preferredUsername,
+				}),
+				followee.mastodonId
+			)
+			.run()
+		await addFollowing(domain, db, connectedActor, followee, { reblogs: false, notify: false, languages: ['en'] })
+		await acceptFollowing(db, connectedActor, followee)
+
+		const req = new Request(`https://${domain}/api/v1/accounts/${followee.mastodonId}/follow`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ reblogs: true, notify: true, languages: ['ja'] }),
+		})
+		const res = await app.fetch(req, { DATABASE: db, userKEK, data: { connectedActor } })
+		await assertStatus(res, 200)
+		const data = await res.json<{ showing_reblogs: boolean; notifying: boolean; languages?: string[] }>()
+		assert.equal(data.showing_reblogs, true)
+		assert.equal(data.notifying, true)
+		assert.deepEqual(data.languages, ['ja'])
+
+		const row = await db
+			.prepare(`SELECT show_reblogs, notify, languages FROM actor_following WHERE actor_id=? AND target_actor_id=?`)
+			.bind(connectedActor.id.toString(), followee.id.toString())
+			.first<{ show_reblogs: number; notify: number; languages: string | null }>()
+		assert.equal(row?.show_reblogs, 1)
+		assert.equal(row?.notify, 1)
+		assert.equal(row?.languages, '["ja"]')
 	})
 })

--- a/packages/backend/src/routes/api/v1/accounts/[id]/follow.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/follow.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert/strict'
 
 import app from '@wildebeest/backend'
 import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { insertBlock } from '@wildebeest/backend/mastodon/block'
 import { makeDB, createTestUser, assertStatus, assertCORS, assertJSON } from '@wildebeest/backend/test/utils'
 import { queryAcct } from '@wildebeest/backend/webfinger'
 
@@ -17,6 +18,39 @@ describe('/api/v1/accounts/[id]/follow', () => {
 		const req = new Request(`https://${domain}/api/v1/accounts/${targetActor[mastodonIdSymbol]}/follow`, {
 			method: 'POST',
 		})
+		const res = await app.fetch(req, { DATABASE: db, userKEK, data: { connectedActor } })
+		await assertStatus(res, 403)
+	})
+
+	test('follow blocked account is forbidden', async () => {
+		const db = makeDB()
+		const connectedActor = await createTestUser(domain, db, userKEK, 'block-follow@cloudflare.com')
+		const followee = {
+			id: new URL('https://example.com/ap/users/blocked'),
+			type: 'Person',
+			inbox: new URL('https://example.com/ap/users/blocked/inbox'),
+			preferredUsername: 'blocked',
+			mastodonId: 'blocked-remote',
+		}
+
+		await db
+			.prepare(
+				`INSERT INTO actors (id, type, username, domain, properties, mastodon_id) VALUES (?, 'Person', 'blocked', 'example.com', ?, ?)`
+			)
+			.bind(
+				followee.id.toString(),
+				JSON.stringify({
+					id: followee.id.toString(),
+					type: 'Person',
+					inbox: followee.inbox.toString(),
+					preferredUsername: followee.preferredUsername,
+				}),
+				followee.mastodonId
+			)
+			.run()
+		await insertBlock(db, connectedActor, followee as unknown as Parameters<typeof insertBlock>[2])
+
+		const req = new Request(`https://${domain}/api/v1/accounts/${followee.mastodonId}/follow`, { method: 'POST' })
 		const res = await app.fetch(req, { DATABASE: db, userKEK, data: { connectedActor } })
 		await assertStatus(res, 403)
 	})
@@ -74,6 +108,9 @@ describe('/api/v1/accounts/[id]/follow', () => {
 		await assertStatus(res, 200)
 		assertCORS(res, req)
 		assertJSON(res)
+		const data = await res.json<{ following: boolean; requested: boolean }>()
+		assert.equal(data.following, true)
+		assert.equal(data.requested, false)
 
 		assert(receivedActivity)
 		assert.equal(receivedActivity.type, 'Follow')

--- a/packages/backend/src/routes/api/v1/accounts/[id]/follow.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/follow.ts
@@ -97,6 +97,7 @@ async function handleRequest(
 		)
 
 		const res = await getRelationship(db, connectedActor, id)
+		// Preserve the existing follow endpoint response while the remote request remains pending.
 		res.following = true
 		res.requested = false
 		res.showing_reblogs = params.reblogs ?? true

--- a/packages/backend/src/routes/api/v1/accounts/[id]/follow.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/follow.ts
@@ -9,9 +9,10 @@ import { deliverToActor } from '@wildebeest/backend/activitypub/deliver'
 import { type Database, getDatabase } from '@wildebeest/backend/database'
 import { notAuthorized, resourceNotFound, unprocessableEntity } from '@wildebeest/backend/errors'
 import { getSigningKey } from '@wildebeest/backend/mastodon/account'
+import { hasBlockBetween } from '@wildebeest/backend/mastodon/block'
 import { addFollowing, isNotFollowing } from '@wildebeest/backend/mastodon/follow'
+import { getRelationship } from '@wildebeest/backend/mastodon/relationship'
 import type { HonoEnv } from '@wildebeest/backend/types'
-import type { Relationship } from '@wildebeest/backend/types/account'
 import { readBody, cors } from '@wildebeest/backend/utils'
 import { actorToHandle } from '@wildebeest/backend/utils/handle'
 import myz from '@wildebeest/backend/utils/zod'
@@ -78,30 +79,23 @@ async function handleRequest(
 		return new Response('', { status: 403 })
 	}
 
+	if (await hasBlockBetween(db, connectedActor, followee)) {
+		return new Response('', { status: 403 })
+	}
+
 	if (await isNotFollowing(db, connectedActor, followee)) {
 		const activity = await createFollowActivity(db, domain, connectedActor, followee)
 		const signingKey = await getSigningKey(userKEK, db, connectedActor)
 		await deliverToActor(signingKey, connectedActor, followee, activity, domain)
-		await addFollowing(domain, db, connectedActor, followee)
+		await addFollowing(domain, db, connectedActor, followee, params)
 	}
 
-	const res: Relationship = {
-		id,
-		following: true,
-		// FIXME: stub
-		showing_reblogs: params.reblogs ?? true,
-		notifying: params.notify ?? false,
-		followed_by: false,
-		blocking: false,
-		blocked_by: false,
-		muting: false,
-		muting_notifications: false,
-		requested: false,
-		domain_blocking: false,
-		endorsed: false,
-		note: '',
-		languages: params.languages ?? undefined,
-	}
+	const res = await getRelationship(db, connectedActor, id)
+	res.following = true
+	res.requested = false
+	res.showing_reblogs = params.reblogs ?? true
+	res.notifying = params.notify ?? false
+	res.languages = params.languages ?? undefined
 	return new Response(JSON.stringify(res), { headers })
 }
 

--- a/packages/backend/src/routes/api/v1/accounts/[id]/follow.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/follow.ts
@@ -5,12 +5,16 @@ import { isLocalAccount } from '@wildebeest/backend/accounts'
 import { createFollowActivity } from '@wildebeest/backend/activitypub/activities/follow'
 import type { Person } from '@wildebeest/backend/activitypub/actors'
 import * as actors from '@wildebeest/backend/activitypub/actors'
-import { deliverToActor } from '@wildebeest/backend/activitypub/deliver'
+import { deliverSafely, deliverToActor } from '@wildebeest/backend/activitypub/deliver'
 import { type Database, getDatabase } from '@wildebeest/backend/database'
 import { notAuthorized, resourceNotFound, unprocessableEntity } from '@wildebeest/backend/errors'
 import { getSigningKey } from '@wildebeest/backend/mastodon/account'
 import { hasBlockBetween } from '@wildebeest/backend/mastodon/block'
-import { addFollowing, isNotFollowing } from '@wildebeest/backend/mastodon/follow'
+import {
+	addFollowing,
+	isFollowingOrFollowingRequested,
+	updateFollowingOptions,
+} from '@wildebeest/backend/mastodon/follow'
 import { getRelationship } from '@wildebeest/backend/mastodon/relationship'
 import type { HonoEnv } from '@wildebeest/backend/types'
 import { readBody, cors } from '@wildebeest/backend/utils'
@@ -83,19 +87,26 @@ async function handleRequest(
 		return new Response('', { status: 403 })
 	}
 
-	if (await isNotFollowing(db, connectedActor, followee)) {
+	const hasExistingFollow = await isFollowingOrFollowingRequested(db, connectedActor, followee)
+	if (!hasExistingFollow) {
 		const activity = await createFollowActivity(db, domain, connectedActor, followee)
 		const signingKey = await getSigningKey(userKEK, db, connectedActor)
-		await deliverToActor(signingKey, connectedActor, followee, activity, domain)
 		await addFollowing(domain, db, connectedActor, followee, params)
+		await deliverSafely(`Follow to ${followee.id.toString()}`, () =>
+			deliverToActor(signingKey, connectedActor, followee, activity, domain)
+		)
+
+		const res = await getRelationship(db, connectedActor, id)
+		res.following = true
+		res.requested = false
+		res.showing_reblogs = params.reblogs ?? true
+		res.notifying = params.notify ?? false
+		res.languages = params.languages ?? undefined
+		return new Response(JSON.stringify(res), { headers })
 	}
 
+	await updateFollowingOptions(db, connectedActor, followee, params)
 	const res = await getRelationship(db, connectedActor, id)
-	res.following = true
-	res.requested = false
-	res.showing_reblogs = params.reblogs ?? true
-	res.notifying = params.notify ?? false
-	res.languages = params.languages ?? undefined
 	return new Response(JSON.stringify(res), { headers })
 }
 

--- a/packages/backend/src/routes/api/v1/accounts/[id]/mute.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/mute.ts
@@ -1,0 +1,71 @@
+// https://docs.joinmastodon.org/methods/accounts/#mute
+
+import { Hono } from 'hono'
+import { z } from 'zod'
+
+import { getActorByMastodonId, type Person } from '@wildebeest/backend/activitypub/actors'
+import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { cacheFromEnv, type Cache } from '@wildebeest/backend/cache'
+import { type Database, getDatabase } from '@wildebeest/backend/database'
+import { notAuthorized, resourceNotFound, unprocessableEntity } from '@wildebeest/backend/errors'
+import { insertMute } from '@wildebeest/backend/mastodon/mute'
+import { getRelationship } from '@wildebeest/backend/mastodon/relationship'
+import * as timeline from '@wildebeest/backend/mastodon/timeline'
+import type { HonoEnv } from '@wildebeest/backend/types'
+import { cors, readBody } from '@wildebeest/backend/utils'
+import myz from '@wildebeest/backend/utils/zod'
+
+const app = new Hono<HonoEnv>()
+
+const schema = z.object({
+	notifications: z.optional(myz.logical()),
+})
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+app.post<'/:id/mute'>(async ({ req, env }) => {
+	if (!env.data.connectedActor) {
+		return notAuthorized('not authorized')
+	}
+	const result = await readBody(req.raw, schema)
+	if (!result.success) {
+		const [issue] = result.error.issues
+		return unprocessableEntity(`${issue?.path.join('.')}: ${issue?.message}`)
+	}
+	return handleRequest(
+		getDatabase(env),
+		env.data.connectedActor,
+		req.param('id'),
+		result.data,
+		new URL(req.url).hostname,
+		cacheFromEnv(env)
+	)
+})
+
+async function handleRequest(
+	db: Database,
+	connectedActor: Person,
+	id: string,
+	params: z.infer<typeof schema>,
+	domain: string,
+	cache: Cache
+): Promise<Response> {
+	const target = await getActorByMastodonId(db, id)
+	if (!target) {
+		return resourceNotFound('id', id)
+	}
+	if (connectedActor[mastodonIdSymbol] === target[mastodonIdSymbol]) {
+		return new Response('', { status: 403 })
+	}
+
+	await insertMute(db, connectedActor, target, params.notifications ?? true)
+	await timeline.pregenerateTimelines(domain, db, cache, connectedActor)
+
+	const res = await getRelationship(db, connectedActor, id)
+	return new Response(JSON.stringify(res), { headers })
+}
+
+export default app

--- a/packages/backend/src/routes/api/v1/accounts/[id]/unblock.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/unblock.ts
@@ -1,0 +1,54 @@
+// https://docs.joinmastodon.org/methods/accounts/#unblock
+
+import { Hono } from 'hono'
+
+import { getActorByMastodonId, type Person } from '@wildebeest/backend/activitypub/actors'
+import { cacheFromEnv, type Cache } from '@wildebeest/backend/cache'
+import { type Database, getDatabase } from '@wildebeest/backend/database'
+import { notAuthorized, resourceNotFound } from '@wildebeest/backend/errors'
+import { deleteBlock } from '@wildebeest/backend/mastodon/block'
+import { getRelationship } from '@wildebeest/backend/mastodon/relationship'
+import * as timeline from '@wildebeest/backend/mastodon/timeline'
+import type { HonoEnv } from '@wildebeest/backend/types'
+import { cors } from '@wildebeest/backend/utils'
+
+const app = new Hono<HonoEnv>()
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+app.post<'/:id/unblock'>(async ({ req, env }) => {
+	if (!env.data.connectedActor) {
+		return notAuthorized('not authorized')
+	}
+	return handleRequest(
+		getDatabase(env),
+		env.data.connectedActor,
+		req.param('id'),
+		new URL(req.url).hostname,
+		cacheFromEnv(env)
+	)
+})
+
+async function handleRequest(
+	db: Database,
+	connectedActor: Person,
+	id: string,
+	domain: string,
+	cache: Cache
+): Promise<Response> {
+	const target = await getActorByMastodonId(db, id)
+	if (!target) {
+		return resourceNotFound('id', id)
+	}
+
+	await deleteBlock(db, connectedActor, target)
+	await timeline.pregenerateTimelines(domain, db, cache, connectedActor)
+
+	const res = await getRelationship(db, connectedActor, id)
+	return new Response(JSON.stringify(res), { headers })
+}
+
+export default app

--- a/packages/backend/src/routes/api/v1/accounts/[id]/unfollow.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/unfollow.test.ts
@@ -64,6 +64,10 @@ describe('/api/v1/accounts/[id]/unfollow', () => {
 		await assertStatus(res, 200)
 		assertCORS(res, req)
 		assertJSON(res)
+		const data = await res.json<{ following: boolean; showing_reblogs: boolean; notifying: boolean }>()
+		assert.equal(data.following, false)
+		assert.equal(data.showing_reblogs, false)
+		assert.equal(data.notifying, false)
 
 		assert(receivedActivity)
 		assert.equal(receivedActivity.type, 'Undo')

--- a/packages/backend/src/routes/api/v1/accounts/[id]/unfollow.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/unfollow.ts
@@ -8,8 +8,8 @@ import { type Database, getDatabase } from '@wildebeest/backend/database'
 import { notAuthorized, resourceNotFound } from '@wildebeest/backend/errors'
 import { getSigningKey } from '@wildebeest/backend/mastodon/account'
 import { isFollowingOrFollowingRequested, removeFollowing } from '@wildebeest/backend/mastodon/follow'
+import { getRelationship } from '@wildebeest/backend/mastodon/relationship'
 import type { HonoEnv, MastodonId } from '@wildebeest/backend/types'
-import type { Relationship } from '@wildebeest/backend/types/account'
 import { cors } from '@wildebeest/backend/utils/cors'
 import { actorToHandle, isLocalHandle } from '@wildebeest/backend/utils/handle'
 
@@ -59,22 +59,8 @@ async function handleRequest({ domain, db, connectedActor, userKEK }: Dependenci
 		await removeFollowing(db, connectedActor, targetActor)
 	}
 
-	const res: Relationship = {
-		id,
-		following: false,
-		// FIXME: stub
-		showing_reblogs: true,
-		notifying: false,
-		followed_by: false,
-		blocking: false,
-		blocked_by: false,
-		muting: false,
-		muting_notifications: false,
-		requested: false,
-		domain_blocking: false,
-		endorsed: false,
-		note: '',
-	}
+	const res = await getRelationship(db, connectedActor, id)
+	res.notifying = false
 	return new Response(JSON.stringify(res), { headers })
 }
 

--- a/packages/backend/src/routes/api/v1/accounts/[id]/unmute.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/unmute.ts
@@ -1,0 +1,54 @@
+// https://docs.joinmastodon.org/methods/accounts/#unmute
+
+import { Hono } from 'hono'
+
+import { getActorByMastodonId, type Person } from '@wildebeest/backend/activitypub/actors'
+import { cacheFromEnv, type Cache } from '@wildebeest/backend/cache'
+import { type Database, getDatabase } from '@wildebeest/backend/database'
+import { notAuthorized, resourceNotFound } from '@wildebeest/backend/errors'
+import { deleteMute } from '@wildebeest/backend/mastodon/mute'
+import { getRelationship } from '@wildebeest/backend/mastodon/relationship'
+import * as timeline from '@wildebeest/backend/mastodon/timeline'
+import type { HonoEnv } from '@wildebeest/backend/types'
+import { cors } from '@wildebeest/backend/utils'
+
+const app = new Hono<HonoEnv>()
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+app.post<'/:id/unmute'>(async ({ req, env }) => {
+	if (!env.data.connectedActor) {
+		return notAuthorized('not authorized')
+	}
+	return handleRequest(
+		getDatabase(env),
+		env.data.connectedActor,
+		req.param('id'),
+		new URL(req.url).hostname,
+		cacheFromEnv(env)
+	)
+})
+
+async function handleRequest(
+	db: Database,
+	connectedActor: Person,
+	id: string,
+	domain: string,
+	cache: Cache
+): Promise<Response> {
+	const target = await getActorByMastodonId(db, id)
+	if (!target) {
+		return resourceNotFound('id', id)
+	}
+
+	await deleteMute(db, connectedActor, target)
+	await timeline.pregenerateTimelines(domain, db, cache, connectedActor)
+
+	const res = await getRelationship(db, connectedActor, id)
+	return new Response(JSON.stringify(res), { headers })
+}
+
+export default app

--- a/packages/backend/src/routes/api/v1/accounts/relationships.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/relationships.test.ts
@@ -2,7 +2,9 @@ import { strict as assert } from 'node:assert/strict'
 
 import app from '@wildebeest/backend'
 import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { insertBlock } from '@wildebeest/backend/mastodon/block'
 import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
+import { insertMute } from '@wildebeest/backend/mastodon/mute'
 import { makeDB, createTestUser, assertStatus, assertCORS, assertJSON } from '@wildebeest/backend/test/utils'
 
 const userKEK = 'test_kek2'
@@ -56,8 +58,10 @@ describe('/api/v1/accounts/relationships', () => {
 		const db = makeDB()
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 		const actor2 = await createTestUser(domain, db, userKEK, 'sven2@cloudflare.com')
-		await addFollowing(domain, db, actor, actor2)
+		await addFollowing(domain, db, actor, actor2, { reblogs: false, notify: true, languages: ['en'] })
 		await acceptFollowing(db, actor, actor2)
+		await addFollowing(domain, db, actor2, actor)
+		await acceptFollowing(db, actor2, actor)
 
 		const req = new Request('https://mastodon.example/api/v1/accounts/relationships?id[]=' + actor2[mastodonIdSymbol])
 		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: actor } })
@@ -66,6 +70,10 @@ describe('/api/v1/accounts/relationships', () => {
 		const data = await res.json<any[]>()
 		assert.equal(data.length, 1)
 		assert.equal(data[0].following, true)
+		assert.equal(data[0].followed_by, true)
+		assert.equal(data[0].showing_reblogs, false)
+		assert.equal(data[0].notifying, true)
+		assert.deepEqual(data[0].languages, ['en'])
 	})
 
 	test('relationships following request', async () => {
@@ -82,5 +90,28 @@ describe('/api/v1/accounts/relationships', () => {
 		assert.equal(data.length, 1)
 		assert.equal(data[0].requested, true)
 		assert.equal(data[0].following, false)
+	})
+
+	test('relationships blocking and muting', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'relationship-blocker@cloudflare.com')
+		const blocked = await createTestUser(domain, db, userKEK, 'relationship-blocked@cloudflare.com')
+		const blockedBy = await createTestUser(domain, db, userKEK, 'relationship-blocked-by@cloudflare.com')
+		const muted = await createTestUser(domain, db, userKEK, 'relationship-muted@cloudflare.com')
+		await insertBlock(db, actor, blocked)
+		await insertBlock(db, blockedBy, actor)
+		await insertMute(db, actor, muted)
+
+		const req = new Request(
+			`https://mastodon.example/api/v1/accounts/relationships?id[]=${blocked[mastodonIdSymbol]}&id[]=${blockedBy[mastodonIdSymbol]}&id[]=${muted[mastodonIdSymbol]}`
+		)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: actor } })
+		await assertStatus(res, 200)
+
+		const data = await res.json<any[]>()
+		assert.equal(data[0].blocking, true)
+		assert.equal(data[1].blocked_by, true)
+		assert.equal(data[2].muting, true)
+		assert.equal(data[2].muting_notifications, true)
 	})
 })

--- a/packages/backend/src/routes/api/v1/accounts/relationships.ts
+++ b/packages/backend/src/routes/api/v1/accounts/relationships.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import type { Person } from '@wildebeest/backend/activitypub/actors'
 import { type Database, getDatabase } from '@wildebeest/backend/database'
 import { notAuthorized } from '@wildebeest/backend/errors'
-import { getFollowingMastodonIds, getFollowingRequestedMastodonIds } from '@wildebeest/backend/mastodon/follow'
+import { getRelationships } from '@wildebeest/backend/mastodon/relationship'
 import type { HonoEnv } from '@wildebeest/backend/types'
 import { cors, readParams } from '@wildebeest/backend/utils'
 
@@ -42,30 +42,7 @@ app.get(async ({ req, env }) => {
 
 async function handleRequest({ db, connectedActor }: Dependencies, params: Parameters): Promise<Response> {
 	const ids = Array.isArray(params.id) ? params.id : [params.id]
-	const following = await getFollowingMastodonIds(db, connectedActor)
-	const followingRequested = await getFollowingRequestedMastodonIds(db, connectedActor)
-
-	return new Response(
-		JSON.stringify(
-			ids.map((id) => ({
-				id,
-				following: following.includes(id),
-				requested: followingRequested.includes(id),
-
-				// FIXME: stub values
-				showing_reblogs: false,
-				notifying: false,
-				followed_by: false,
-				blocking: false,
-				blocked_by: false,
-				muting: false,
-				muting_notifications: false,
-				domain_blocking: false,
-				endorsed: false,
-			}))
-		),
-		{ headers }
-	)
+	return new Response(JSON.stringify(await getRelationships(db, connectedActor, ids)), { headers })
 }
 
 export default app

--- a/packages/backend/src/routes/api/v1/blocks.test.ts
+++ b/packages/backend/src/routes/api/v1/blocks.test.ts
@@ -74,6 +74,28 @@ describe('/api/v1/blocks', () => {
 		assert.equal(row?.count, 0)
 	})
 
+	test('block returns relationship when timeline regeneration fails', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'cache-failure-blocker@cloudflare.com')
+		const target = await createTestUser(domain, db, userKEK, 'cache-failure-blocked@cloudflare.com')
+		const failingCache = {
+			async get<T>(): Promise<T | null> {
+				return null
+			},
+			async put<T>(_key: string, _value: T): Promise<void> {
+				throw new Error('cache write failed')
+			},
+		}
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${target[mastodonIdSymbol]}/block`, { method: 'POST' }),
+			{ DATABASE: db, DO_CACHE: makeDOCache(failingCache), data: { connectedActor: actor } }
+		)
+		await assertStatus(res, 200)
+		const relationship = await res.json<{ blocking: boolean }>()
+		assert.equal(relationship.blocking, true)
+	})
+
 	test('block regenerates cached home timeline', async () => {
 		const db = makeDB()
 		const cache = makeCache()

--- a/packages/backend/src/routes/api/v1/blocks.test.ts
+++ b/packages/backend/src/routes/api/v1/blocks.test.ts
@@ -1,15 +1,128 @@
 import { strict as assert } from 'node:assert/strict'
 
-import blocks from '@wildebeest/backend/routes/api/v1/blocks'
-import { assertStatus, assertJSON } from '@wildebeest/backend/test/utils'
+import app from '@wildebeest/backend'
+import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
+import { createPublicStatus } from '@wildebeest/backend/test/shared.utils'
+import {
+	assertStatus,
+	assertJSON,
+	createTestUser,
+	makeCache,
+	makeDB,
+	makeDOCache,
+} from '@wildebeest/backend/test/utils'
+import { MastodonStatus } from '@wildebeest/backend/types'
+
+const userKEK = 'test_kek_blocks'
+const domain = 'cloudflare.com'
 
 describe('/api/v1/blocks', () => {
-	test('blocks returns an empty array', async () => {
-		const res = await blocks.request('/')
+	test('block, list, and unblock accounts', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'blocker@cloudflare.com')
+		const target = await createTestUser(domain, db, userKEK, 'blocked@cloudflare.com')
+
+		const blockRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${target[mastodonIdSymbol]}/block`, { method: 'POST' }),
+			{ DATABASE: db, DO_CACHE: makeDOCache(), data: { connectedActor: actor } }
+		)
+		await assertStatus(blockRes, 200)
+		const relationship = await blockRes.json<{ blocking: boolean }>()
+		assert.equal(relationship.blocking, true)
+
+		const res = await app.fetch(new Request(`https://${domain}/api/v1/blocks`), {
+			DATABASE: db,
+			data: { connectedActor: actor },
+		})
 		await assertStatus(res, 200)
 		assertJSON(res)
 
-		const data = await res.json<any>()
-		assert.equal(data.length, 0)
+		const data = await res.json<Array<{ id: string }>>()
+		assert.equal(data.length, 1)
+		assert.equal(data[0]?.id, target[mastodonIdSymbol])
+
+		const unblockRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${target[mastodonIdSymbol]}/unblock`, { method: 'POST' }),
+			{ DATABASE: db, DO_CACHE: makeDOCache(), data: { connectedActor: actor } }
+		)
+		await assertStatus(unblockRes, 200)
+		const unblocked = await unblockRes.json<{ blocking: boolean }>()
+		assert.equal(unblocked.blocking, false)
+	})
+
+	test('block removes existing follows in both directions', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'follow-blocker@cloudflare.com')
+		const target = await createTestUser(domain, db, userKEK, 'follow-blocked@cloudflare.com')
+
+		await addFollowing(domain, db, actor, target)
+		await acceptFollowing(db, actor, target)
+		await addFollowing(domain, db, target, actor)
+		await acceptFollowing(db, target, actor)
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${target[mastodonIdSymbol]}/block`, { method: 'POST' }),
+			{ DATABASE: db, DO_CACHE: makeDOCache(), data: { connectedActor: actor } }
+		)
+		await assertStatus(res, 200)
+		const relationship = await res.json<{ blocking: boolean; following: boolean; followed_by: boolean }>()
+		assert.equal(relationship.blocking, true)
+		assert.equal(relationship.following, false)
+
+		const row = await db.prepare(`SELECT count(*) as count FROM actor_following`).first<{ count: number }>()
+		assert.equal(row?.count, 0)
+	})
+
+	test('block regenerates cached home timeline', async () => {
+		const db = makeDB()
+		const cache = makeCache()
+		const actor = await createTestUser(domain, db, userKEK, 'cache-blocker@cloudflare.com')
+		const target = await createTestUser(domain, db, userKEK, 'cache-blocked@cloudflare.com')
+		const visible = await createTestUser(domain, db, userKEK, 'cache-visible@cloudflare.com')
+
+		for (const account of [target, visible]) {
+			await addFollowing(domain, db, actor, account)
+			await acceptFollowing(db, actor, account)
+			await createPublicStatus(domain, db, account, `post from ${account.preferredUsername}`)
+		}
+		await addFollowing(domain, db, target, actor)
+		await acceptFollowing(db, target, actor)
+		await createPublicStatus(domain, db, actor, 'post from blocker')
+		await cache.put(actor.id.toString() + '/timeline/home', 'stale timeline')
+		await cache.put(target.id.toString() + '/timeline/home', 'stale target timeline')
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${target[mastodonIdSymbol]}/block`, { method: 'POST' }),
+			{ DATABASE: db, DO_CACHE: makeDOCache(cache), data: { connectedActor: actor } }
+		)
+		await assertStatus(res, 200)
+
+		const timeline = await cache.get<MastodonStatus[]>(actor.id.toString() + '/timeline/home')
+		assert.equal(
+			timeline?.some((status) => status.account.username === 'cache-blocked'),
+			false
+		)
+		assert.equal(
+			timeline?.some((status) => status.account.username === 'cache-visible'),
+			true
+		)
+
+		const targetTimeline = await cache.get<MastodonStatus[]>(target.id.toString() + '/timeline/home')
+		assert.equal(
+			targetTimeline?.some((status) => status.account.username === 'cache-blocker'),
+			false
+		)
+	})
+
+	test('self block is forbidden', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'self-blocker@cloudflare.com')
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${actor[mastodonIdSymbol]}/block`, { method: 'POST' }),
+			{ DATABASE: db, data: { connectedActor: actor } }
+		)
+		await assertStatus(res, 403)
 	})
 })

--- a/packages/backend/src/routes/api/v1/blocks.ts
+++ b/packages/backend/src/routes/api/v1/blocks.ts
@@ -1,10 +1,49 @@
 import { Hono } from 'hono'
+import { z } from 'zod'
 
+import { getAccountByMastodonId } from '@wildebeest/backend/accounts'
+import { type Database, getDatabase } from '@wildebeest/backend/database'
+import { notAuthorized } from '@wildebeest/backend/errors'
+import { getBlockedMastodonIds } from '@wildebeest/backend/mastodon/block'
 import { HonoEnv } from '@wildebeest/backend/types'
+import type { MastodonAccount } from '@wildebeest/backend/types/account'
+import { cors, readParams } from '@wildebeest/backend/utils'
 
 const app = new Hono<HonoEnv>()
 
-// TODO: implement
-app.get((c) => c.json([]))
+const schema = z.object({
+	limit: z.coerce.number().int().positive().max(80).default(40),
+	max_id: z.string().optional(),
+})
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+app.get(async ({ req, env }) => {
+	if (!env.data.connectedActor) {
+		return notAuthorized('not authorized')
+	}
+	const params = await readParams(req.raw, schema)
+	if (!params.success) {
+		return new Response('', { status: 400 })
+	}
+	const domain = new URL(req.url).hostname
+	return handleRequest(getDatabase(env), env.data.connectedActor, domain, params.data)
+})
+
+async function handleRequest(
+	db: Database,
+	connectedActor: NonNullable<HonoEnv['Bindings']['data']['connectedActor']>,
+	domain: string,
+	params: z.infer<typeof schema>
+): Promise<Response> {
+	const ids = await getBlockedMastodonIds(db, connectedActor, { limit: params.limit, maxId: params.max_id })
+	const accounts = (await Promise.all(ids.map((id) => getAccountByMastodonId(domain, db, id)))).filter(
+		(account): account is MastodonAccount => account !== null
+	)
+	return new Response(JSON.stringify(accounts), { headers })
+}
 
 export default app

--- a/packages/backend/src/routes/api/v1/bookmarks.ts
+++ b/packages/backend/src/routes/api/v1/bookmarks.ts
@@ -1,18 +1,19 @@
+// https://docs.joinmastodon.org/methods/bookmarks/
+
 import { Hono } from 'hono'
 import { z } from 'zod'
 
-import { getAccountByMastodonId } from '@wildebeest/backend/accounts'
 import { type Database, getDatabase } from '@wildebeest/backend/database'
 import { notAuthorized } from '@wildebeest/backend/errors'
-import { getMutedMastodonIds } from '@wildebeest/backend/mastodon/mute'
-import { HonoEnv } from '@wildebeest/backend/types'
-import type { MastodonAccount } from '@wildebeest/backend/types/account'
+import { getBookmarkedObjectIds } from '@wildebeest/backend/mastodon/bookmark'
+import { loadViewerStatusesByObjectIds } from '@wildebeest/backend/mastodon/status_response'
+import type { HonoEnv } from '@wildebeest/backend/types'
 import { cors, readParams } from '@wildebeest/backend/utils'
 
 const app = new Hono<HonoEnv>()
 
 const schema = z.object({
-	limit: z.coerce.number().int().positive().max(80).default(40),
+	limit: z.coerce.number().int().positive().max(40).default(20),
 	max_id: z.string().optional(),
 })
 
@@ -39,11 +40,9 @@ async function handleRequest(
 	domain: string,
 	params: z.infer<typeof schema>
 ): Promise<Response> {
-	const ids = await getMutedMastodonIds(db, connectedActor, { limit: params.limit, maxId: params.max_id })
-	const accounts = (await Promise.all(ids.map((id) => getAccountByMastodonId(domain, db, id)))).filter(
-		(account): account is MastodonAccount => account !== null
-	)
-	return new Response(JSON.stringify(accounts), { headers })
+	const objectIds = await getBookmarkedObjectIds(db, connectedActor, { limit: params.limit, maxId: params.max_id })
+	const statuses = await loadViewerStatusesByObjectIds(db, domain, objectIds, connectedActor)
+	return new Response(JSON.stringify(statuses), { headers })
 }
 
 export default app

--- a/packages/backend/src/routes/api/v1/favourites.ts
+++ b/packages/backend/src/routes/api/v1/favourites.ts
@@ -1,18 +1,19 @@
+// https://docs.joinmastodon.org/methods/favourites/
+
 import { Hono } from 'hono'
 import { z } from 'zod'
 
-import { getAccountByMastodonId } from '@wildebeest/backend/accounts'
 import { type Database, getDatabase } from '@wildebeest/backend/database'
 import { notAuthorized } from '@wildebeest/backend/errors'
-import { getMutedMastodonIds } from '@wildebeest/backend/mastodon/mute'
-import { HonoEnv } from '@wildebeest/backend/types'
-import type { MastodonAccount } from '@wildebeest/backend/types/account'
+import { getFavouritedObjectIds } from '@wildebeest/backend/mastodon/like'
+import { loadViewerStatusesByObjectIds } from '@wildebeest/backend/mastodon/status_response'
+import type { HonoEnv } from '@wildebeest/backend/types'
 import { cors, readParams } from '@wildebeest/backend/utils'
 
 const app = new Hono<HonoEnv>()
 
 const schema = z.object({
-	limit: z.coerce.number().int().positive().max(80).default(40),
+	limit: z.coerce.number().int().positive().max(40).default(20),
 	max_id: z.string().optional(),
 })
 
@@ -39,11 +40,9 @@ async function handleRequest(
 	domain: string,
 	params: z.infer<typeof schema>
 ): Promise<Response> {
-	const ids = await getMutedMastodonIds(db, connectedActor, { limit: params.limit, maxId: params.max_id })
-	const accounts = (await Promise.all(ids.map((id) => getAccountByMastodonId(domain, db, id)))).filter(
-		(account): account is MastodonAccount => account !== null
-	)
-	return new Response(JSON.stringify(accounts), { headers })
+	const objectIds = await getFavouritedObjectIds(db, connectedActor, { limit: params.limit, maxId: params.max_id })
+	const statuses = await loadViewerStatusesByObjectIds(db, domain, objectIds, connectedActor)
+	return new Response(JSON.stringify(statuses), { headers })
 }
 
 export default app

--- a/packages/backend/src/routes/api/v1/mutes.test.ts
+++ b/packages/backend/src/routes/api/v1/mutes.test.ts
@@ -1,13 +1,93 @@
-import mutes from '@wildebeest/backend/routes/api/v1/mutes'
-import { assertStatus, assertJSON } from '@wildebeest/backend/test/utils'
+import { strict as assert } from 'node:assert/strict'
+
+import app from '@wildebeest/backend'
+import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { assertStatus, assertJSON, createTestUser, makeDB, makeDOCache } from '@wildebeest/backend/test/utils'
+
+const userKEK = 'test_kek_mutes'
+const domain = 'cloudflare.com'
 
 describe('/api/v1/mutes', () => {
-	test('mutes returns an empty array', async () => {
-		const res = await mutes.request('/')
+	test('mute, list, and unmute accounts', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'muter@cloudflare.com')
+		const target = await createTestUser(domain, db, userKEK, 'muted@cloudflare.com')
+
+		const muteRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${target[mastodonIdSymbol]}/mute`, { method: 'POST' }),
+			{ DATABASE: db, DO_CACHE: makeDOCache(), data: { connectedActor: actor } }
+		)
+		await assertStatus(muteRes, 200)
+		const relationship = await muteRes.json<{ muting: boolean; muting_notifications: boolean }>()
+		assert.equal(relationship.muting, true)
+		assert.equal(relationship.muting_notifications, true)
+
+		const res = await app.fetch(new Request(`https://${domain}/api/v1/mutes`), {
+			DATABASE: db,
+			data: { connectedActor: actor },
+		})
 		await assertStatus(res, 200)
 		assertJSON(res)
 
-		const data = await res.json<unknown[]>()
-		expect(data.length).toBe(0)
+		const data = await res.json<Array<{ id: string }>>()
+		assert.equal(data.length, 1)
+		assert.equal(data[0]?.id, target[mastodonIdSymbol])
+
+		const unmuteRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${target[mastodonIdSymbol]}/unmute`, { method: 'POST' }),
+			{ DATABASE: db, DO_CACHE: makeDOCache(), data: { connectedActor: actor } }
+		)
+		await assertStatus(unmuteRes, 200)
+		const unmuted = await unmuteRes.json<{ muting: boolean }>()
+		assert.equal(unmuted.muting, false)
+	})
+
+	test('self mute is forbidden', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'self-muter@cloudflare.com')
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${actor[mastodonIdSymbol]}/mute`, { method: 'POST' }),
+			{ DATABASE: db, data: { connectedActor: actor } }
+		)
+		await assertStatus(res, 403)
+	})
+
+	test('mute persists notification preference in relationships', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'muter-notifications@cloudflare.com')
+		const target = await createTestUser(domain, db, userKEK, 'muted-notifications@cloudflare.com')
+
+		const muteRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${target[mastodonIdSymbol]}/mute`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ notifications: false }),
+			}),
+			{ DATABASE: db, DO_CACHE: makeDOCache(), data: { connectedActor: actor } }
+		)
+		await assertStatus(muteRes, 200)
+		const muted = await muteRes.json<{ muting: boolean; muting_notifications: boolean }>()
+		assert.equal(muted.muting, true)
+		assert.equal(muted.muting_notifications, false)
+
+		const relationshipsRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/relationships?id[]=${target[mastodonIdSymbol]}`),
+			{ DATABASE: db, data: { connectedActor: actor } }
+		)
+		await assertStatus(relationshipsRes, 200)
+
+		const relationships = await relationshipsRes.json<Array<{ muting: boolean; muting_notifications: boolean }>>()
+		assert.equal(relationships[0].muting, true)
+		assert.equal(relationships[0].muting_notifications, false)
+
+		const remuteRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/accounts/${target[mastodonIdSymbol]}/mute`, { method: 'POST' }),
+			{ DATABASE: db, DO_CACHE: makeDOCache(), data: { connectedActor: actor } }
+		)
+		await assertStatus(remuteRes, 200)
+		const remuted = await remuteRes.json<{ muting: boolean; muting_notifications: boolean }>()
+		assert.equal(remuted.muting, true)
+		assert.equal(remuted.muting_notifications, true)
 	})
 })

--- a/packages/backend/src/routes/api/v1/statuses/[id].test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id].test.ts
@@ -30,8 +30,7 @@ describe('/api/v1/statuses/[id]', () => {
 		await assertStatus(res, 200)
 
 		const data = await res.json<{ favourites_count: unknown }>()
-		// FIXME: temporarly disable favourites counts
-		assert.equal(data.favourites_count, 0)
+		assert.equal(data.favourites_count, 2)
 	})
 
 	test('get status with image', async () => {
@@ -76,8 +75,7 @@ describe('/api/v1/statuses/[id]', () => {
 		await assertStatus(res, 200)
 
 		const data = await res.json<{ reblogs_count: unknown }>()
-		// FIXME: temporarly disable reblogs counts
-		assert.equal(data.reblogs_count, 0)
+		assert.equal(data.reblogs_count, 2)
 	})
 
 	test('update non-existing status', async () => {

--- a/packages/backend/src/routes/api/v1/statuses/[id]/bookmark.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/bookmark.test.ts
@@ -1,0 +1,93 @@
+import { strict as assert } from 'node:assert/strict'
+
+import app from '@wildebeest/backend'
+import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { insertLike } from '@wildebeest/backend/mastodon/like'
+import { createPrivateStatus, createPublicStatus } from '@wildebeest/backend/test/shared.utils'
+import { assertStatus, createTestUser, makeDB } from '@wildebeest/backend/test/utils'
+
+const userKEK = 'test_kek_bookmark'
+const domain = 'cloudflare.com'
+
+describe('/api/v1/statuses/[id]/bookmark', () => {
+	test('bookmark and unbookmark update API-visible state', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'bookmark@cloudflare.com')
+		const note = await createPublicStatus(domain, db, actor, 'bookmarked status')
+
+		const bookmarkRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/bookmark`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(bookmarkRes, 200)
+		const bookmarked = await bookmarkRes.json<{ bookmarked: boolean; favourited: boolean }>()
+		assert.equal(bookmarked.bookmarked, true)
+		assert.equal(bookmarked.favourited, false)
+
+		const unbookmarkRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/unbookmark`, { method: 'POST' }),
+			{ DATABASE: db, userKEK, data: { connectedActor: actor } }
+		)
+		await assertStatus(unbookmarkRes, 200)
+		const unbookmarked = await unbookmarkRes.json<{ bookmarked: boolean }>()
+		assert.equal(unbookmarked.bookmarked, false)
+
+		const listRes = await app.fetch(new Request(`https://${domain}/api/v1/bookmarks`), {
+			DATABASE: db,
+			userKEK,
+			data: { connectedActor: actor },
+		})
+		await assertStatus(listRes, 200)
+		const statuses = await listRes.json<Array<{ id: string }>>()
+		assert.deepEqual(statuses, [])
+	})
+
+	test('bookmarks list returns bookmarked statuses', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'bookmarks-list@cloudflare.com')
+		const note = await createPublicStatus(domain, db, actor, 'listed bookmark')
+		await insertLike(db, actor, note)
+
+		const bookmarkRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/bookmark`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(bookmarkRes, 200)
+
+		const res = await app.fetch(new Request(`https://${domain}/api/v1/bookmarks`), {
+			DATABASE: db,
+			userKEK,
+			data: { connectedActor: actor },
+		})
+		await assertStatus(res, 200)
+		const statuses = await res.json<Array<{ id: string; bookmarked: boolean; favourited: boolean }>>()
+		assert.equal(statuses.length, 1)
+		assert.equal(statuses[0]?.id, note[mastodonIdSymbol])
+		assert.equal(statuses[0]?.bookmarked, true)
+		assert.equal(statuses[0]?.favourited, true)
+	})
+
+	test('bookmark rejects private status hidden from viewer before mutation', async () => {
+		const db = makeDB()
+		const author = await createTestUser(domain, db, userKEK, 'private-bookmark-author@cloudflare.com')
+		const viewer = await createTestUser(domain, db, userKEK, 'private-bookmark-viewer@cloudflare.com')
+		const note = await createPrivateStatus(domain, db, author, 'private bookmark')
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/bookmark`, { method: 'POST' }),
+			{ DATABASE: db, userKEK, data: { connectedActor: viewer } }
+		)
+		await assertStatus(res, 404)
+
+		const row = await db.prepare(`SELECT count(*) as count FROM bookmarks`).first<{ count: number }>()
+		assert.equal(row?.count, 0)
+	})
+})

--- a/packages/backend/src/routes/api/v1/statuses/[id]/bookmark.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/bookmark.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert/strict'
 
 import app from '@wildebeest/backend'
 import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { insertBlock } from '@wildebeest/backend/mastodon/block'
 import { insertLike } from '@wildebeest/backend/mastodon/like'
 import { createPrivateStatus, createPublicStatus } from '@wildebeest/backend/test/shared.utils'
 import { assertStatus, createTestUser, makeDB } from '@wildebeest/backend/test/utils'
@@ -89,5 +90,28 @@ describe('/api/v1/statuses/[id]/bookmark', () => {
 
 		const row = await db.prepare(`SELECT count(*) as count FROM bookmarks`).first<{ count: number }>()
 		assert.equal(row?.count, 0)
+	})
+
+	test('bookmarks list hides statuses blocked after bookmarking', async () => {
+		const db = makeDB()
+		const viewer = await createTestUser(domain, db, userKEK, 'blocked-bookmark-viewer@cloudflare.com')
+		const author = await createTestUser(domain, db, userKEK, 'blocked-bookmark-author@cloudflare.com')
+		const note = await createPublicStatus(domain, db, author, 'blocked after bookmark')
+
+		const bookmarkRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/bookmark`, { method: 'POST' }),
+			{ DATABASE: db, userKEK, data: { connectedActor: viewer } }
+		)
+		await assertStatus(bookmarkRes, 200)
+		await insertBlock(db, author, viewer)
+
+		const res = await app.fetch(new Request(`https://${domain}/api/v1/bookmarks`), {
+			DATABASE: db,
+			userKEK,
+			data: { connectedActor: viewer },
+		})
+		await assertStatus(res, 200)
+		const statuses = await res.json<Array<{ id: string }>>()
+		assert.equal(statuses.length, 0)
 	})
 })

--- a/packages/backend/src/routes/api/v1/statuses/[id]/bookmark.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/bookmark.ts
@@ -1,0 +1,44 @@
+// https://docs.joinmastodon.org/methods/statuses/#bookmark
+
+import { Hono } from 'hono'
+
+import type { Person } from '@wildebeest/backend/activitypub/actors'
+import { type Database, getDatabase } from '@wildebeest/backend/database'
+import { notAuthorized, recordNotFound } from '@wildebeest/backend/errors'
+import { insertBookmark } from '@wildebeest/backend/mastodon/bookmark'
+import { loadVisibleStatusObject, toViewerStatusResponse } from '@wildebeest/backend/mastodon/status_response'
+import type { HonoEnv } from '@wildebeest/backend/types'
+import { cors } from '@wildebeest/backend/utils/cors'
+
+const app = new Hono<HonoEnv>()
+
+app.post<'/:id/bookmark'>(async ({ req, env }) => {
+	if (!env.data.connectedActor) {
+		return notAuthorized('not authorized')
+	}
+	const domain = new URL(req.url).hostname
+	return handleRequest(getDatabase(env), req.param('id'), env.data.connectedActor, domain)
+})
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+async function handleRequest(db: Database, id: string, connectedActor: Person, domain: string): Promise<Response> {
+	const obj = await loadVisibleStatusObject(db, domain, id, connectedActor)
+	if (obj === null) {
+		return recordNotFound(`object ${id} not found`)
+	}
+
+	await insertBookmark(db, connectedActor, obj)
+
+	const status = await toViewerStatusResponse(db, domain, obj, connectedActor)
+	if (status === null) {
+		return recordNotFound(`object ${id} not found`)
+	}
+
+	return new Response(JSON.stringify(status), { headers })
+}
+
+export default app

--- a/packages/backend/src/routes/api/v1/statuses/[id]/favourite.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/favourite.test.ts
@@ -11,9 +11,9 @@ const userKEK = 'test_kek4'
 const domain = 'cloudflare.com'
 
 describe('/api/v1/statuses/[id]/favourite', () => {
-	test('favourite status sends Like activity', async () => {
+	test('favourite status sends Like activity once', async () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		let deliveredActivity: any = null
+		const deliveredActivities: any[] = []
 
 		const db = makeDB()
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
@@ -21,7 +21,7 @@ describe('/api/v1/statuses/[id]/favourite', () => {
 
 		await db
 			.prepare(
-				'INSERT INTO objects (id, type, properties, original_actor_id, original_object_id, local, mastodon_id) VALUES (?, ?, ?, ?, ?, 1, ?)'
+				'INSERT INTO objects (id, type, properties, original_actor_id, original_object_id, local, mastodon_id) VALUES (?, ?, ?, ?, ?, 0, ?)'
 			)
 			.bind(
 				'https://example.com/object1',
@@ -50,8 +50,7 @@ describe('/api/v1/statuses/[id]/favourite', () => {
 			const request = new Request(input)
 			if (request.url === actor.id.toString() + '/inbox') {
 				assert.equal(request.method, 'POST')
-				const body = await request.json()
-				deliveredActivity = body
+				deliveredActivities.push(await request.json())
 				return new Response()
 			}
 
@@ -60,13 +59,16 @@ describe('/api/v1/statuses/[id]/favourite', () => {
 
 		const connectedActor = actor
 
-		const req = new Request(`https://${domain}/api/v1/statuses/mastodonid1/favourite`)
+		const req = new Request(`https://${domain}/api/v1/statuses/mastodonid1/favourite`, { method: 'POST' })
 		const res = await app.fetch(req, { DATABASE: db, userKEK, data: { connectedActor } })
 		await assertStatus(res, 200)
 
-		assert(deliveredActivity)
-		assert.equal(deliveredActivity.type, 'Like')
-		assert.equal(deliveredActivity.object, originalObjectId)
+		const duplicateRes = await app.fetch(req, { DATABASE: db, userKEK, data: { connectedActor } })
+		await assertStatus(duplicateRes, 200)
+
+		assert.equal(deliveredActivities.length, 1)
+		assert.equal(deliveredActivities[0].type, 'Like')
+		assert.equal(deliveredActivities[0].object, originalObjectId)
 	})
 
 	test('favourite records in db', async () => {
@@ -76,7 +78,7 @@ describe('/api/v1/statuses/[id]/favourite', () => {
 
 		const connectedActor = actor
 
-		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/favourite`)
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/favourite`, { method: 'POST' })
 		const res = await app.fetch(req, { DATABASE: db, userKEK, data: { connectedActor } })
 		await assertStatus(res, 200)
 

--- a/packages/backend/src/routes/api/v1/statuses/[id]/favourite.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/favourite.test.ts
@@ -71,6 +71,60 @@ describe('/api/v1/statuses/[id]/favourite', () => {
 		assert.equal(deliveredActivities[0].object, originalObjectId)
 	})
 
+	test('favourite keeps local state when Like delivery fails', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'favourite-delivery-failure@cloudflare.com')
+		const originalObjectId = 'https://example.com/failed-like-note'
+
+		await db
+			.prepare(
+				'INSERT INTO objects (id, type, properties, original_actor_id, original_object_id, local, mastodon_id) VALUES (?, ?, ?, ?, ?, 0, ?)'
+			)
+			.bind(
+				'https://example.com/failed-like-object',
+				'Note',
+				JSON.stringify({
+					attributedTo: actor.id.toString(),
+					id: originalObjectId,
+					type: 'Note',
+					content: 'remote status',
+					source: {
+						content: 'remote status',
+						mediaType: 'text/markdown',
+					},
+					to: [PUBLIC_GROUP],
+					cc: [],
+					attachment: [],
+					sensitive: false,
+				} satisfies Note),
+				actor.id.toString(),
+				originalObjectId,
+				'failed-like-mastodon-id'
+			)
+			.run()
+
+		globalThis.fetch = async (input: RequestInfo) => {
+			const request = new Request(input)
+			if (request.url === actor.id.toString() + '/inbox') {
+				return new Response('temporary failure', { status: 503 })
+			}
+
+			throw new Error('unexpected request to ' + request.url)
+		}
+
+		const req = new Request(`https://${domain}/api/v1/statuses/failed-like-mastodon-id/favourite`, { method: 'POST' })
+		const res = await app.fetch(req, { DATABASE: db, userKEK, data: { connectedActor: actor } })
+		await assertStatus(res, 200)
+		const data = await res.json<{ favourited: boolean }>()
+		assert.equal(data.favourited, true)
+
+		const row = await db
+			.prepare(`SELECT actor_id, object_id FROM actor_favourites`)
+			.first<{ actor_id: string; object_id: string }>()
+		assert.equal(row?.actor_id, actor.id.toString())
+		assert.equal(row?.object_id, 'https://example.com/failed-like-object')
+	})
+
 	test('favourite records in db', async () => {
 		const db = makeDB()
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')

--- a/packages/backend/src/routes/api/v1/statuses/[id]/favourite.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/favourite.ts
@@ -4,7 +4,7 @@ import { Hono } from 'hono'
 
 import { createLikeActivity } from '@wildebeest/backend/activitypub/activities/like'
 import { getAndCacheActor, type Person } from '@wildebeest/backend/activitypub/actors'
-import { deliverToActor } from '@wildebeest/backend/activitypub/deliver'
+import { deliverSafely, deliverToActor } from '@wildebeest/backend/activitypub/deliver'
 import {
 	getApId,
 	isLocalObject,
@@ -57,7 +57,9 @@ async function handleRequest(
 		// Liking an external object delivers the like activity
 		const activity = await createLikeActivity(db, domain, connectedActor, new URL(obj[originalObjectIdSymbol]))
 		const signingKey = await getSigningKey(userKEK, db, connectedActor)
-		await deliverToActor(signingKey, connectedActor, targetActor, activity, domain)
+		await deliverSafely(`Like to ${targetActor.id.toString()}`, () =>
+			deliverToActor(signingKey, connectedActor, targetActor, activity, domain)
+		)
 	}
 
 	const status = await toViewerStatusResponse(db, domain, obj, connectedActor)

--- a/packages/backend/src/routes/api/v1/statuses/[id]/favourite.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/favourite.ts
@@ -55,11 +55,11 @@ async function handleRequest(
 	const created = await insertLike(db, connectedActor, obj)
 	if (created && targetActor) {
 		// Liking an external object delivers the like activity
-		const activity = await createLikeActivity(db, domain, connectedActor, new URL(obj[originalObjectIdSymbol]))
-		const signingKey = await getSigningKey(userKEK, db, connectedActor)
-		await deliverSafely(`Like to ${targetActor.id.toString()}`, () =>
-			deliverToActor(signingKey, connectedActor, targetActor, activity, domain)
-		)
+		await deliverSafely(`Like to ${targetActor.id.toString()}`, async () => {
+			const activity = await createLikeActivity(db, domain, connectedActor, new URL(obj[originalObjectIdSymbol]))
+			const signingKey = await getSigningKey(userKEK, db, connectedActor)
+			await deliverToActor(signingKey, connectedActor, targetActor, activity, domain)
+		})
 	}
 
 	const status = await toViewerStatusResponse(db, domain, obj, connectedActor)

--- a/packages/backend/src/routes/api/v1/statuses/[id]/favourite.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/favourite.ts
@@ -7,23 +7,21 @@ import { getAndCacheActor, type Person } from '@wildebeest/backend/activitypub/a
 import { deliverToActor } from '@wildebeest/backend/activitypub/deliver'
 import {
 	getApId,
-	getObjectByMastodonId,
 	isLocalObject,
 	originalActorIdSymbol,
 	originalObjectIdSymbol,
 } from '@wildebeest/backend/activitypub/objects'
-import type { Note } from '@wildebeest/backend/activitypub/objects/note'
 import { type Database, getDatabase } from '@wildebeest/backend/database'
 import { notAuthorized } from '@wildebeest/backend/errors'
 import { getSigningKey } from '@wildebeest/backend/mastodon/account'
 import { insertLike } from '@wildebeest/backend/mastodon/like'
-import { toMastodonStatusFromObject } from '@wildebeest/backend/mastodon/status'
+import { loadVisibleStatusObject, toViewerStatusResponse } from '@wildebeest/backend/mastodon/status_response'
 import type { HonoEnv } from '@wildebeest/backend/types'
 import { cors } from '@wildebeest/backend/utils/cors'
 
 const app = new Hono<HonoEnv>()
 
-app.get<'/:id/favourite'>(async ({ req, env }) => {
+app.post<'/:id/favourite'>(async ({ req, env }) => {
 	if (!env.data.connectedActor) {
 		return notAuthorized('not authorized')
 	}
@@ -43,30 +41,29 @@ async function handleRequest(
 	userKEK: string,
 	domain: string
 ): Promise<Response> {
-	const obj = await getObjectByMastodonId<Note>(domain, db, id)
+	const obj = await loadVisibleStatusObject(db, domain, id, connectedActor)
 	if (obj === null) {
 		return new Response('', { status: 404 })
 	}
 
-	const status = await toMastodonStatusFromObject(db, obj, domain)
-	if (status === null) {
-		return new Response('', { status: 404 })
+	const isRemoteObject = !isLocalObject(domain, getApId(obj.id))
+	const targetActor = isRemoteObject ? await getAndCacheActor(new URL(obj[originalActorIdSymbol]), db) : null
+	if (isRemoteObject && !targetActor) {
+		return new Response(`target Actor ${obj[originalActorIdSymbol]} not found`, { status: 404 })
 	}
 
-	if (!isLocalObject(domain, getApId(obj.id))) {
+	const created = await insertLike(db, connectedActor, obj)
+	if (created && targetActor) {
 		// Liking an external object delivers the like activity
-		const targetActor = await getAndCacheActor(new URL(obj[originalActorIdSymbol]), db)
-		if (!targetActor) {
-			return new Response(`target Actor ${obj[originalActorIdSymbol]} not found`, { status: 404 })
-		}
-
 		const activity = await createLikeActivity(db, domain, connectedActor, new URL(obj[originalObjectIdSymbol]))
 		const signingKey = await getSigningKey(userKEK, db, connectedActor)
 		await deliverToActor(signingKey, connectedActor, targetActor, activity, domain)
 	}
 
-	await insertLike(db, connectedActor, obj)
-	status.favourited = true
+	const status = await toViewerStatusResponse(db, domain, obj, connectedActor)
+	if (status === null) {
+		return new Response('', { status: 404 })
+	}
 
 	return new Response(JSON.stringify(status), { headers })
 }

--- a/packages/backend/src/routes/api/v1/statuses/[id]/reblog.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/reblog.test.ts
@@ -188,4 +188,62 @@ describe('/api/v1/statuses/[id]/reblog', () => {
 		assert.equal(deliveredActivity.actor, actor.id.toString())
 		assert.equal(deliveredActivity.object, originalObjectId)
 	})
+
+	test('reblog remote status keeps local state when Announce delivery fails', async () => {
+		const db = makeDB()
+		const queue = makeQueue()
+		const actor = await createTestUser(domain, db, userKEK, 'reblog-delivery-failure@cloudflare.com')
+		const originalObjectId = 'https://example.com/failed-announce-note'
+
+		await db
+			.prepare(
+				'INSERT INTO objects (id, type, properties, original_actor_id, original_object_id, mastodon_id, local) VALUES (?, ?, ?, ?, ?, ?, 0)'
+			)
+			.bind(
+				'https://example.com/failed-announce-object',
+				'Note',
+				JSON.stringify({
+					attributedTo: actor.id.toString(),
+					id: 'failed-announce',
+					type: 'Note',
+					content: 'remote status',
+					source: {
+						content: 'remote status',
+						mediaType: 'text/markdown',
+					},
+					to: [PUBLIC_GROUP],
+					cc: [],
+					attachment: [],
+					sensitive: false,
+				} satisfies Note),
+				actor.id.toString(),
+				originalObjectId,
+				'failed-announce-mastodon-id'
+			)
+			.run()
+
+		globalThis.fetch = async (input: RequestInfo) => {
+			const request = new Request(input)
+			if (request.url === actor.id.toString() + '/inbox') {
+				return new Response('temporary failure', { status: 503 })
+			}
+
+			throw new Error('unexpected request to ' + request.url)
+		}
+
+		const req = new Request(`https://${domain}/api/v1/statuses/failed-announce-mastodon-id/reblog`, {
+			method: 'POST',
+			body: JSON.stringify({ visibility: 'public' }),
+		})
+		const res = await app.fetch(req, { DATABASE: db, QUEUE: queue, userKEK, data: { connectedActor: actor } })
+		await assertStatus(res, 200)
+		const data = await res.json<{ reblogged: boolean }>()
+		assert.equal(data.reblogged, true)
+
+		const row = await db
+			.prepare(`SELECT actor_id, object_id FROM actor_reblogs`)
+			.first<{ actor_id: string; object_id: string }>()
+		assert.equal(row?.actor_id, actor.id.toString())
+		assert.equal(row?.object_id, 'https://example.com/failed-announce-object')
+	})
 })

--- a/packages/backend/src/routes/api/v1/statuses/[id]/reblog.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/reblog.test.ts
@@ -4,8 +4,10 @@ import app from '@wildebeest/backend'
 import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
 import { type Note } from '@wildebeest/backend/activitypub/objects/note'
-import { createPublicStatus } from '@wildebeest/backend/test/shared.utils'
+import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
+import { createDirectStatus, createPublicStatus } from '@wildebeest/backend/test/shared.utils'
 import { makeDB, makeQueue, createTestUser, assertStatus } from '@wildebeest/backend/test/utils'
+import { MessageType } from '@wildebeest/backend/types'
 
 const userKEK = 'test_kek4'
 const domain = 'cloudflare.com'
@@ -26,8 +28,9 @@ describe('/api/v1/statuses/[id]/reblog', () => {
 		const res = await app.fetch(req, { DATABASE: db, QUEUE: queue, userKEK, data: { connectedActor } })
 		await assertStatus(res, 200)
 
-		const data = await res.json<{ reblogged: unknown }>()
+		const data = await res.json<{ reblogged: unknown; reblogs_count: number }>()
 		assert.equal(data.reblogged, true)
+		assert.equal(data.reblogs_count, 1)
 
 		const row = await db.prepare(`SELECT * FROM actor_reblogs`).first<{ actor_id: string; object_id: string }>()
 		assert.ok(row)
@@ -54,6 +57,73 @@ describe('/api/v1/statuses/[id]/reblog', () => {
 		assert.ok(row)
 		assert.equal(row.actor_id, actor.id.toString())
 		assert.equal(row.object_id, note.id.toString())
+	})
+
+	test('reblog local status delivers Announce activity to followers', async () => {
+		const db = makeDB()
+		const queue = makeQueue()
+
+		const actor = await createTestUser(domain, db, userKEK, 'local-reblog@cloudflare.com')
+		const follower = await createTestUser(domain, db, userKEK, 'local-reblog-follower@cloudflare.com')
+		const note = await createPublicStatus(domain, db, actor, 'local reblog status')
+
+		await addFollowing(domain, db, follower, actor)
+		await acceptFollowing(db, follower, actor)
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/reblog`, {
+			method: 'POST',
+			body: JSON.stringify({ visibility: 'public' }),
+		})
+		const res = await app.fetch(req, { DATABASE: db, QUEUE: queue, userKEK, data: { connectedActor: actor } })
+		await assertStatus(res, 200)
+
+		assert.equal(queue.messages.length, 1)
+		assert.equal(queue.messages[0].type, MessageType.Deliver)
+		assert.equal(queue.messages[0].toActorId, follower.id.toString())
+		assert.equal(queue.messages[0].activity.type, 'Announce')
+	})
+
+	test.each([
+		{ visibility: 'public', expectedStatus: 404 },
+		{ visibility: 'unlisted', expectedStatus: 404 },
+		{ visibility: 'private', expectedStatus: 404 },
+		{ visibility: 'direct', expectedStatus: 200 },
+	])('self reblog direct status as $visibility', async ({ visibility, expectedStatus }) => {
+		const db = makeDB()
+		const queue = makeQueue()
+		const actor = await createTestUser(domain, db, userKEK, `direct-reblog-${visibility}@cloudflare.com`)
+		const note = await createDirectStatus(domain, db, actor, 'direct reblog status')
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/reblog`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ visibility }),
+		})
+		const res = await app.fetch(req, { DATABASE: db, QUEUE: queue, userKEK, data: { connectedActor: actor } })
+		await assertStatus(res, expectedStatus)
+
+		const row = await db.prepare(`SELECT count(*) as count FROM actor_reblogs`).first<{ count: number }>()
+		assert.equal(row?.count, expectedStatus === 200 ? 1 : 0)
+	})
+
+	test('direct reblog does not deliver Announce activity to followers', async () => {
+		const db = makeDB()
+		const queue = makeQueue()
+		const actor = await createTestUser(domain, db, userKEK, 'direct-reblog-no-fanout@cloudflare.com')
+		const follower = await createTestUser(domain, db, userKEK, 'direct-reblog-no-fanout-follower@cloudflare.com')
+		await addFollowing(domain, db, follower, actor)
+		await acceptFollowing(db, follower, actor)
+		const note = await createDirectStatus(domain, db, actor, 'direct reblog status')
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/reblog`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ visibility: 'direct' }),
+		})
+		const res = await app.fetch(req, { DATABASE: db, QUEUE: queue, userKEK, data: { connectedActor: actor } })
+		await assertStatus(res, 200)
+
+		assert.equal(queue.messages.length, 0)
 	})
 
 	test('reblog remote status status sends Announce activity to author', async () => {

--- a/packages/backend/src/routes/api/v1/statuses/[id]/reblog.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/reblog.ts
@@ -4,21 +4,23 @@ import { z } from 'zod'
 
 import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import { createAnnounceActivity } from '@wildebeest/backend/activitypub/activities/announce'
-import { getAndCacheActor, type Person } from '@wildebeest/backend/activitypub/actors'
-import { deliverFollowers, deliverToActor } from '@wildebeest/backend/activitypub/deliver'
+import { type Person } from '@wildebeest/backend/activitypub/actors'
 import {
 	getApId,
 	getObjectByMastodonId,
-	isLocalObject,
 	originalActorIdSymbol,
 	originalObjectIdSymbol,
 } from '@wildebeest/backend/activitypub/objects'
 import { isNote, type Note } from '@wildebeest/backend/activitypub/objects/note'
 import { type Database, getDatabase } from '@wildebeest/backend/database'
 import { notAuthorized, recordNotFound } from '@wildebeest/backend/errors'
-import { getSigningKey } from '@wildebeest/backend/mastodon/account'
-import { createReblog } from '@wildebeest/backend/mastodon/reblog'
-import { toMastodonStatusFromObject } from '@wildebeest/backend/mastodon/status'
+import { deliverCreatedAnnounce, getRemoteAnnounceTargetActor } from '@wildebeest/backend/mastodon/announce_delivery'
+import { createReblog, hasReblog } from '@wildebeest/backend/mastodon/reblog'
+import {
+	canViewStatus,
+	setMastodonStatusViewerState,
+	toMastodonStatusFromObject,
+} from '@wildebeest/backend/mastodon/status'
 import type { DeliverMessageBody, HonoEnv, Queue, Visibility } from '@wildebeest/backend/types'
 import { readBody } from '@wildebeest/backend/utils'
 import { cors } from '@wildebeest/backend/utils/cors'
@@ -76,13 +78,20 @@ async function handleRequest(
 	if (!isNote(obj)) {
 		return recordNotFound(`object ${id} not found`)
 	}
+	if (!(await canViewStatus(db, obj, connectedActor))) {
+		return recordNotFound(`object ${id} not found`)
+	}
 	if (reblogNotAllowed(connectedActor, obj, visibility)) {
 		return recordNotFound(`object ${id} not found`)
 	}
 
-	const status = await toMastodonStatusFromObject(db, obj, domain)
-	if (status === null) {
-		return recordNotFound(`object ${id} not found`)
+	if (await hasReblog(db, connectedActor, obj)) {
+		const status = await toMastodonStatusFromObject(db, obj, domain)
+		if (status === null) {
+			return recordNotFound(`object ${id} not found`)
+		}
+		await setMastodonStatusViewerState(db, status, obj, connectedActor)
+		return new Response(JSON.stringify(status), { headers })
 	}
 
 	const to = new Set<string>()
@@ -104,31 +113,34 @@ async function handleRequest(
 		if (obj.attributedTo) {
 			cc.add(getApId(obj.attributedTo).toString())
 		}
+	} else if (visibility === 'direct') {
+		to.add(connectedActor.id.toString())
 	}
 
-	let activity
-	if (isLocalObject(domain, getApId(obj))) {
-		activity = await createAnnounceActivity(db, domain, connectedActor, new URL(obj.id), to, cc)
-	} else {
-		// Reblogging an external object delivers the announce activity to the post author.
-		const targetActor = await getAndCacheActor(new URL(obj[originalActorIdSymbol]), db)
-		if (targetActor === null) {
-			return recordNotFound(`target Actor ${obj[originalActorIdSymbol]} not found`)
-		}
-
-		const signingKey = await getSigningKey(userKEK, db, connectedActor)
-		activity = await createAnnounceActivity(db, domain, connectedActor, new URL(obj[originalObjectIdSymbol]), to, cc)
-
-		await Promise.all([
-			// Delivers the announce activity to the post author.
-			deliverToActor(signingKey, connectedActor, targetActor, activity, domain),
-			// Share reblogged by delivering the announce activity to followers
-			deliverFollowers(db, userKEK, connectedActor, activity, queue),
-		])
+	const objectId = new URL(obj[originalObjectIdSymbol] ?? obj.id.toString())
+	const targetActor = await getRemoteAnnounceTargetActor(db, domain, connectedActor, obj, { skipSelf: false })
+	if (targetActor === null) {
+		return recordNotFound(`target Actor ${obj[originalActorIdSymbol]} not found`)
 	}
 
-	await createReblog(db, connectedActor, obj, activity, activity.published ?? new Date().toISOString())
-	status.reblogged = true
+	const activity = await createAnnounceActivity(
+		db,
+		domain,
+		connectedActor,
+		targetActor ? objectId : new URL(obj.id),
+		to,
+		cc
+	)
+	const created = await createReblog(db, connectedActor, obj, activity, activity.published ?? new Date().toISOString())
+	if (created) {
+		await deliverCreatedAnnounce(db, userKEK, connectedActor, activity, queue, domain, targetActor)
+	}
+
+	const status = await toMastodonStatusFromObject(db, obj, domain)
+	if (status === null) {
+		return recordNotFound(`object ${id} not found`)
+	}
+	await setMastodonStatusViewerState(db, status, obj, connectedActor)
 
 	return new Response(JSON.stringify(status), { headers })
 }
@@ -157,7 +169,7 @@ function reblogNotAllowed(
 		return visibility === 'public' || visibility === 'unlisted'
 	}
 
-	return visibility === 'direct'
+	return visibility !== 'direct'
 }
 
 export default app

--- a/packages/backend/src/routes/api/v1/statuses/[id]/unbookmark.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/unbookmark.ts
@@ -1,0 +1,44 @@
+// https://docs.joinmastodon.org/methods/statuses/#unbookmark
+
+import { Hono } from 'hono'
+
+import type { Person } from '@wildebeest/backend/activitypub/actors'
+import { type Database, getDatabase } from '@wildebeest/backend/database'
+import { notAuthorized, recordNotFound } from '@wildebeest/backend/errors'
+import { deleteBookmark } from '@wildebeest/backend/mastodon/bookmark'
+import { loadVisibleStatusObject, toViewerStatusResponse } from '@wildebeest/backend/mastodon/status_response'
+import type { HonoEnv } from '@wildebeest/backend/types'
+import { cors } from '@wildebeest/backend/utils/cors'
+
+const app = new Hono<HonoEnv>()
+
+app.post<'/:id/unbookmark'>(async ({ req, env }) => {
+	if (!env.data.connectedActor) {
+		return notAuthorized('not authorized')
+	}
+	const domain = new URL(req.url).hostname
+	return handleRequest(getDatabase(env), req.param('id'), env.data.connectedActor, domain)
+})
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+async function handleRequest(db: Database, id: string, connectedActor: Person, domain: string): Promise<Response> {
+	const obj = await loadVisibleStatusObject(db, domain, id, connectedActor)
+	if (obj === null) {
+		return recordNotFound(`object ${id} not found`)
+	}
+
+	await deleteBookmark(db, connectedActor, obj)
+
+	const status = await toViewerStatusResponse(db, domain, obj, connectedActor)
+	if (status === null) {
+		return recordNotFound(`object ${id} not found`)
+	}
+
+	return new Response(JSON.stringify(status), { headers })
+}
+
+export default app

--- a/packages/backend/src/routes/api/v1/statuses/[id]/unfavourite.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/unfavourite.test.ts
@@ -1,0 +1,55 @@
+import { strict as assert } from 'node:assert/strict'
+
+import app from '@wildebeest/backend'
+import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { insertBookmark } from '@wildebeest/backend/mastodon/bookmark'
+import { insertLike } from '@wildebeest/backend/mastodon/like'
+import { createPublicStatus } from '@wildebeest/backend/test/shared.utils'
+import { assertStatus, createTestUser, makeDB } from '@wildebeest/backend/test/utils'
+
+const userKEK = 'test_kek_unfavourite'
+const domain = 'cloudflare.com'
+
+describe('/api/v1/statuses/[id]/unfavourite', () => {
+	test('unfavourite removes favourite and favourites list returns favourites', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'unfavourite@cloudflare.com')
+		const note = await createPublicStatus(domain, db, actor, 'favourited status')
+		await insertLike(db, actor, note)
+		await insertBookmark(db, actor, note)
+
+		const listRes = await app.fetch(new Request(`https://${domain}/api/v1/favourites`), {
+			DATABASE: db,
+			userKEK,
+			data: { connectedActor: actor },
+		})
+		await assertStatus(listRes, 200)
+		const statuses = await listRes.json<Array<{ id: string; favourited: boolean; bookmarked: boolean }>>()
+		assert.equal(statuses.length, 1)
+		assert.equal(statuses[0]?.id, note[mastodonIdSymbol])
+		assert.equal(statuses[0]?.favourited, true)
+		assert.equal(statuses[0]?.bookmarked, true)
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/unfavourite`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(res, 200)
+		const data = await res.json<{ favourited: boolean; bookmarked: boolean }>()
+		assert.equal(data.favourited, false)
+		assert.equal(data.bookmarked, true)
+
+		const emptyListRes = await app.fetch(new Request(`https://${domain}/api/v1/favourites`), {
+			DATABASE: db,
+			userKEK,
+			data: { connectedActor: actor },
+		})
+		await assertStatus(emptyListRes, 200)
+		const emptyStatuses = await emptyListRes.json<Array<{ id: string }>>()
+		assert.deepEqual(emptyStatuses, [])
+	})
+})

--- a/packages/backend/src/routes/api/v1/statuses/[id]/unfavourite.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/unfavourite.ts
@@ -1,0 +1,44 @@
+// https://docs.joinmastodon.org/methods/statuses/#unfavourite
+
+import { Hono } from 'hono'
+
+import type { Person } from '@wildebeest/backend/activitypub/actors'
+import { type Database, getDatabase } from '@wildebeest/backend/database'
+import { notAuthorized, recordNotFound } from '@wildebeest/backend/errors'
+import { deleteLike } from '@wildebeest/backend/mastodon/like'
+import { loadVisibleStatusObject, toViewerStatusResponse } from '@wildebeest/backend/mastodon/status_response'
+import type { HonoEnv } from '@wildebeest/backend/types'
+import { cors } from '@wildebeest/backend/utils/cors'
+
+const app = new Hono<HonoEnv>()
+
+app.post<'/:id/unfavourite'>(async ({ req, env }) => {
+	if (!env.data.connectedActor) {
+		return notAuthorized('not authorized')
+	}
+	const domain = new URL(req.url).hostname
+	return handleRequest(getDatabase(env), req.param('id'), env.data.connectedActor, domain)
+})
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+async function handleRequest(db: Database, id: string, connectedActor: Person, domain: string): Promise<Response> {
+	const obj = await loadVisibleStatusObject(db, domain, id, connectedActor)
+	if (obj === null) {
+		return recordNotFound(`object ${id} not found`)
+	}
+
+	await deleteLike(db, connectedActor, obj)
+
+	const status = await toViewerStatusResponse(db, domain, obj, connectedActor)
+	if (status === null) {
+		return recordNotFound(`object ${id} not found`)
+	}
+
+	return new Response(JSON.stringify(status), { headers })
+}
+
+export default app

--- a/packages/backend/src/routes/api/v1/statuses/[id]/unreblog.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/unreblog.test.ts
@@ -253,4 +253,100 @@ describe('/api/v1/statuses/[id]/unreblog', () => {
 		assert.deepEqual(deliveredActivities[1].to, deliveredActivities[1].object.to)
 		assert.deepEqual(deliveredActivities[1].cc, deliveredActivities[1].object.cc)
 	})
+
+	test('unreblog remote status keeps local state when Undo delivery fails', async () => {
+		let inboxRequests = 0
+		const db = makeDB()
+		const queue = makeQueue()
+		const actor = await createTestUser(domain, db, userKEK, 'remote-unreblog-delivery-failure@cloudflare.com')
+		const remoteActorId = 'https://example.com/users/undo-failure-author'
+		const originalObjectId = 'https://example.com/notes/undo-failure'
+		const localObjectId = 'https://cloudflare.com/ap/o/undo-failure-note'
+
+		await db
+			.prepare(
+				`INSERT INTO actors (id, type, username, domain, properties, mastodon_id)
+					VALUES (?, 'Person', 'undo-failure-author', 'example.com', ?, ?)`
+			)
+			.bind(
+				remoteActorId,
+				JSON.stringify({
+					id: remoteActorId,
+					type: 'Person',
+					preferredUsername: 'undo-failure-author',
+					inbox: `${remoteActorId}/inbox`,
+					outbox: `${remoteActorId}/outbox`,
+					following: `${remoteActorId}/following`,
+					followers: `${remoteActorId}/followers`,
+				}),
+				'undo-failure-author-mastodon-id'
+			)
+			.run()
+
+		await db
+			.prepare(
+				'INSERT INTO objects (id, type, properties, original_actor_id, original_object_id, mastodon_id, local) VALUES (?, ?, ?, ?, ?, ?, 0)'
+			)
+			.bind(
+				localObjectId,
+				'Note',
+				JSON.stringify({
+					id: originalObjectId,
+					type: 'Note',
+					attributedTo: remoteActorId,
+					content: 'remote status',
+					source: {
+						content: 'remote status',
+						mediaType: 'text/markdown',
+					},
+					to: [PUBLIC_GROUP],
+					cc: [],
+					attachment: [],
+					sensitive: false,
+				} satisfies Note),
+				remoteActorId,
+				originalObjectId,
+				'undo-failure-status-mastodon-id'
+			)
+			.run()
+		await addFollowing(domain, db, { id: new URL(remoteActorId) }, actor)
+		await acceptFollowing(db, { id: new URL(remoteActorId) }, actor)
+
+		globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
+			const request = new Request(input)
+			if (request.url === `${remoteActorId}/inbox`) {
+				inboxRequests += 1
+				return inboxRequests === 1 ? new Response() : new Response('temporary failure', { status: 503 })
+			}
+
+			throw new Error('unexpected request to ' + request.url)
+		}
+
+		const reblogRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/undo-failure-status-mastodon-id/reblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				QUEUE: queue,
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(reblogRes, 200)
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/undo-failure-status-mastodon-id/unreblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				DO_CACHE: makeDOCache(),
+				QUEUE: queue,
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(res, 200)
+		assert.equal(inboxRequests, 2)
+
+		const row = await db.prepare(`SELECT count(*) as count FROM actor_reblogs`).first<{ count: number }>()
+		assert.equal(row?.count, 0)
+	})
 })

--- a/packages/backend/src/routes/api/v1/statuses/[id]/unreblog.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/unreblog.test.ts
@@ -13,6 +13,12 @@ const userKEK = 'test_kek_unreblog'
 const domain = 'cloudflare.com'
 
 describe('/api/v1/statuses/[id]/unreblog', () => {
+	const originalFetch = globalThis.fetch
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch
+	})
+
 	test('unreblog removes reblog', async () => {
 		const db = makeDB()
 		const actor = await createTestUser(domain, db, userKEK, 'unreblog@cloudflare.com')

--- a/packages/backend/src/routes/api/v1/statuses/[id]/unreblog.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/unreblog.test.ts
@@ -1,0 +1,256 @@
+import { strict as assert } from 'node:assert/strict'
+
+import app from '@wildebeest/backend'
+import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
+import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { type Note } from '@wildebeest/backend/activitypub/objects/note'
+import { insertBlock } from '@wildebeest/backend/mastodon/block'
+import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
+import { createDirectStatus, createPublicStatus } from '@wildebeest/backend/test/shared.utils'
+import { assertStatus, createTestUser, makeDB, makeDOCache, makeQueue } from '@wildebeest/backend/test/utils'
+
+const userKEK = 'test_kek_unreblog'
+const domain = 'cloudflare.com'
+
+describe('/api/v1/statuses/[id]/unreblog', () => {
+	test('unreblog removes reblog', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'unreblog@cloudflare.com')
+		const note = await createPublicStatus(domain, db, actor, 'reblogged status')
+
+		const reblogRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/reblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				userKEK,
+				QUEUE: makeQueue(),
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(reblogRes, 200)
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/unreblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				DO_CACHE: makeDOCache(),
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(res, 200)
+		const data = await res.json<{ reblogged: boolean; reblogs_count: number }>()
+		assert.equal(data.reblogged, false)
+		assert.equal(data.reblogs_count, 0)
+
+		const outboxRows = await db.prepare('SELECT count(*) as count FROM outbox_objects').first<{ count: number }>()
+		assert.equal(outboxRows?.count, 1)
+	})
+
+	test('unreblog rejects status hidden by block before mutation', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'blocked-unreblogger@cloudflare.com')
+		const author = await createTestUser(domain, db, userKEK, 'blocked-unreblog-author@cloudflare.com')
+		const note = await createPublicStatus(domain, db, author, 'blocked unreblog status')
+
+		const reblogRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/reblog`, { method: 'POST' }),
+			{ DATABASE: db, QUEUE: makeQueue(), userKEK, data: { connectedActor: actor } }
+		)
+		await assertStatus(reblogRes, 200)
+		await insertBlock(db, author, actor)
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/unreblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				DO_CACHE: makeDOCache(),
+				QUEUE: makeQueue(),
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(res, 404)
+
+		const row = await db.prepare(`SELECT count(*) as count FROM actor_reblogs`).first<{ count: number }>()
+		assert.equal(row?.count, 1)
+	})
+
+	test('unreblog local status does not deliver Undo Announce to local author inbox', async () => {
+		globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
+			const request = new Request(input)
+			throw new Error('unexpected request to ' + request.url)
+		}
+
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'local-unreblogger@cloudflare.com')
+		const author = await createTestUser(domain, db, userKEK, 'local-unreblog-author@cloudflare.com')
+		const note = await createPublicStatus(domain, db, author, 'local status reblogged by another user')
+
+		const reblogRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/reblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				QUEUE: makeQueue(),
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(reblogRes, 200)
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/unreblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				DO_CACHE: makeDOCache(),
+				QUEUE: makeQueue(),
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(res, 200)
+		const data = await res.json<{ reblogged: boolean; reblogs_count: number }>()
+		assert.equal(data.reblogged, false)
+		assert.equal(data.reblogs_count, 0)
+	})
+
+	test('direct unreblog does not deliver Undo Announce activity to followers', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'direct-unreblogger@cloudflare.com')
+		const follower = await createTestUser(domain, db, userKEK, 'direct-unreblog-follower@cloudflare.com')
+		await addFollowing(domain, db, follower, actor)
+		await acceptFollowing(db, follower, actor)
+		const note = await createDirectStatus(domain, db, actor, 'direct unreblog status')
+
+		const reblogQueue = makeQueue()
+		const reblogRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/reblog`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ visibility: 'direct' }),
+			}),
+			{ DATABASE: db, QUEUE: reblogQueue, userKEK, data: { connectedActor: actor } }
+		)
+		await assertStatus(reblogRes, 200)
+		assert.equal(reblogQueue.messages.length, 0)
+
+		const unreblogQueue = makeQueue()
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/unreblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				DO_CACHE: makeDOCache(),
+				QUEUE: unreblogQueue,
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(res, 200)
+		assert.equal(unreblogQueue.messages.length, 0)
+	})
+
+	test('unreblog remote status sends Undo Announce activity to author', async () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const deliveredActivities: any[] = []
+		const db = makeDB()
+		const queue = makeQueue()
+		const actor = await createTestUser(domain, db, userKEK, 'remote-unreblog@cloudflare.com')
+		const remoteActorId = 'https://example.com/users/author'
+		const originalObjectId = 'https://example.com/notes/1'
+		const localObjectId = 'https://cloudflare.com/ap/o/remote-note-1'
+
+		await db
+			.prepare(
+				`INSERT INTO actors (id, type, username, domain, properties, mastodon_id)
+				VALUES (?, 'Person', 'author', 'example.com', ?, ?)`
+			)
+			.bind(
+				remoteActorId,
+				JSON.stringify({
+					id: remoteActorId,
+					type: 'Person',
+					preferredUsername: 'author',
+					inbox: `${remoteActorId}/inbox`,
+					outbox: `${remoteActorId}/outbox`,
+					following: `${remoteActorId}/following`,
+					followers: `${remoteActorId}/followers`,
+				}),
+				'author-mastodon-id'
+			)
+			.run()
+
+		await db
+			.prepare(
+				'INSERT INTO objects (id, type, properties, original_actor_id, original_object_id, mastodon_id, local) VALUES (?, ?, ?, ?, ?, ?, 0)'
+			)
+			.bind(
+				localObjectId,
+				'Note',
+				JSON.stringify({
+					id: originalObjectId,
+					type: 'Note',
+					attributedTo: remoteActorId,
+					content: 'remote status',
+					source: {
+						content: 'remote status',
+						mediaType: 'text/markdown',
+					},
+					to: [PUBLIC_GROUP],
+					cc: [],
+					attachment: [],
+					sensitive: false,
+				} satisfies Note),
+				remoteActorId,
+				originalObjectId,
+				'remote-status-mastodon-id'
+			)
+			.run()
+		await addFollowing(domain, db, { id: new URL(remoteActorId) }, actor)
+		await acceptFollowing(db, { id: new URL(remoteActorId) }, actor)
+
+		globalThis.fetch = async (input: Parameters<typeof fetch>[0]) => {
+			const request = new Request(input)
+			if (request.url === `${remoteActorId}/inbox`) {
+				assert.equal(request.method, 'POST')
+				deliveredActivities.push(await request.json())
+				return new Response()
+			}
+
+			throw new Error('unexpected request to ' + request.url)
+		}
+
+		const reblogRes = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/remote-status-mastodon-id/reblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				QUEUE: queue,
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(reblogRes, 200)
+
+		const res = await app.fetch(
+			new Request(`https://${domain}/api/v1/statuses/remote-status-mastodon-id/unreblog`, { method: 'POST' }),
+			{
+				DATABASE: db,
+				DO_CACHE: makeDOCache(),
+				QUEUE: queue,
+				userKEK,
+				data: { connectedActor: actor },
+			}
+		)
+		await assertStatus(res, 200)
+
+		assert.equal(deliveredActivities.length, 2)
+		assert.equal(queue.messages.length, 0)
+		assert.equal(deliveredActivities[0].type, 'Announce')
+		assert.equal(deliveredActivities[1].type, 'Undo')
+		assert.equal(deliveredActivities[1].actor, actor.id.toString())
+		assert.equal(deliveredActivities[1].object.type, 'Announce')
+		assert.equal(deliveredActivities[1].object.actor, actor.id.toString())
+		assert.equal(deliveredActivities[1].object.object, originalObjectId)
+		assert.deepEqual(deliveredActivities[1].to, deliveredActivities[1].object.to)
+		assert.deepEqual(deliveredActivities[1].cc, deliveredActivities[1].object.cc)
+	})
+})

--- a/packages/backend/src/routes/api/v1/statuses/[id]/unreblog.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/unreblog.ts
@@ -1,0 +1,84 @@
+// https://docs.joinmastodon.org/methods/statuses/#unreblog
+
+import { Hono } from 'hono'
+
+import { createUndoAnnounceActivity } from '@wildebeest/backend/activitypub/activities/undo'
+import { type Person } from '@wildebeest/backend/activitypub/actors'
+import { getObjectByMastodonId } from '@wildebeest/backend/activitypub/objects'
+import { isNote, type Note } from '@wildebeest/backend/activitypub/objects/note'
+import { cacheFromEnv, type Cache } from '@wildebeest/backend/cache'
+import { type Database, getDatabase } from '@wildebeest/backend/database'
+import { notAuthorized, recordNotFound } from '@wildebeest/backend/errors'
+import { deliverUndoAnnounce, getRemoteAnnounceTargetActor } from '@wildebeest/backend/mastodon/announce_delivery'
+import { deleteReblog, getReblogActivity } from '@wildebeest/backend/mastodon/reblog'
+import {
+	canViewStatus,
+	setMastodonStatusViewerState,
+	toMastodonStatusFromObject,
+} from '@wildebeest/backend/mastodon/status'
+import * as timeline from '@wildebeest/backend/mastodon/timeline'
+import type { DeliverMessageBody, HonoEnv, Queue } from '@wildebeest/backend/types'
+import { cors } from '@wildebeest/backend/utils/cors'
+
+const app = new Hono<HonoEnv>()
+
+app.post<'/:id/unreblog'>(async ({ req, env }) => {
+	if (!env.data.connectedActor) {
+		return notAuthorized('not authorized')
+	}
+	const domain = new URL(req.url).hostname
+	return handleRequest(
+		getDatabase(env),
+		req.param('id'),
+		env.data.connectedActor,
+		domain,
+		cacheFromEnv(env),
+		env.userKEK,
+		env.QUEUE
+	)
+})
+
+const headers = {
+	...cors(),
+	'content-type': 'application/json; charset=utf-8',
+}
+
+async function handleRequest(
+	db: Database,
+	id: string,
+	connectedActor: Person,
+	domain: string,
+	cache: Cache,
+	userKEK: string,
+	queue: Queue<DeliverMessageBody>
+): Promise<Response> {
+	const obj = await getObjectByMastodonId<Note>(domain, db, id)
+	if (obj === null || !isNote(obj)) {
+		return recordNotFound(`object ${id} not found`)
+	}
+
+	if (!(await canViewStatus(db, obj, connectedActor))) {
+		return recordNotFound(`object ${id} not found`)
+	}
+
+	const reblogActivity = await getReblogActivity(db, connectedActor, obj)
+	const deleted = await deleteReblog(db, connectedActor, obj)
+	if (deleted && reblogActivity !== null) {
+		const undoActivity = await createUndoAnnounceActivity(db, domain, connectedActor, reblogActivity)
+		const targetActor = await getRemoteAnnounceTargetActor(db, domain, connectedActor, obj, { skipSelf: true })
+		if (targetActor !== null) {
+			await deliverUndoAnnounce(db, userKEK, connectedActor, reblogActivity, undoActivity, queue, domain, targetActor)
+		}
+	}
+	await timeline.pregenerateTimelines(domain, db, cache, connectedActor)
+
+	const status = await toMastodonStatusFromObject(db, obj, domain)
+	if (status === null) {
+		return recordNotFound(`object ${id} not found`)
+	}
+	await setMastodonStatusViewerState(db, status, obj, connectedActor)
+
+	return new Response(JSON.stringify(status), { headers })
+}
+
+export default app

--- a/packages/backend/src/test/shared.utils.ts
+++ b/packages/backend/src/test/shared.utils.ts
@@ -62,6 +62,7 @@ export async function createReply(
 	)
 	await addObjectInOutbox(db, author, replyNote)
 	await insertReply(db, author, replyNote, originalNote)
+	return replyNote
 }
 
 /**

--- a/packages/backend/src/utils/hono.ts
+++ b/packages/backend/src/utils/hono.ts
@@ -127,6 +127,9 @@ const publicMiddleware = (): MiddlewareHandler<HonoEnv> => {
 
 const privateMiddleware = (): MiddlewareHandler<HonoEnv> => {
 	return async (c, next) => {
+		if (c.req.method === 'OPTIONS') {
+			return next()
+		}
 		if (import.meta.env.MODE === 'test') {
 			if ((c as { env?: { data?: { connectedActor?: unknown } } }).env?.data?.connectedActor) {
 				return next()


### PR DESCRIPTION
## Summary
- Add Mastodon-compatible social interaction endpoints for bookmarks, favourites, unreblog, block, mute, and relationship state.
- Return viewer state for statuses and keep interaction counts current for local user actions.
- Add ActivityPub Announce/Undo delivery helpers and idempotent handling for repeated reblogs/favourites.

## Compatibility notes
- `/api/v1/statuses/:id/favourite` now uses Mastodon-compatible `POST` handling.
- `/api/v1/blocks` and `/api/v1/mutes` now require authentication instead of returning a public empty list.

## Verification
- `pnpm run test`
- pre-commit `pretty` and `lint`
- pre-push `test`
