### PR TITLE
Enforce status visibility

### DIFF
--- a/packages/backend/src/activitypub/activities/follow.test.ts
+++ b/packages/backend/src/activitypub/activities/follow.test.ts
@@ -4,7 +4,8 @@ import app from '@wildebeest/backend'
 import { Activity, FollowActivity } from '@wildebeest/backend/activitypub/activities'
 import * as activityHandler from '@wildebeest/backend/activitypub/activities/handle'
 import { getApId } from '@wildebeest/backend/activitypub/objects'
-import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
+import { insertBlock } from '@wildebeest/backend/mastodon/block'
+import { acceptFollowing, addFollowing, isFollowingOrFollowingRequested } from '@wildebeest/backend/mastodon/follow'
 import { assertStatus, createActivityId, createTestUser, makeDB } from '@wildebeest/backend/test/utils'
 import { JWK } from '@wildebeest/backend/webpush/jwk'
 
@@ -163,6 +164,30 @@ describe('Follow', () => {
 		assert.equal(entry.type, 'follow')
 		assert.equal(entry.actor_id.toString(), actor.id.toString())
 		assert.equal(entry.from_actor_id.toString(), actor2.id.toString())
+	})
+
+	test('ignores blocked follow without accepting it', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'blocked-followee@cloudflare.com')
+		const actor2 = await createTestUser(domain, db, userKEK, 'blocked-follower@cloudflare.com')
+		await insertBlock(db, actor, actor2)
+
+		const activity: Activity = {
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: createActivityId(domain),
+			type: 'Follow',
+			actor: actor2.id,
+			object: actor.id,
+		}
+
+		await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
+
+		assert.equal(receivedActivity, null)
+		assert.equal(await isFollowingOrFollowingRequested(db, actor2, actor), false)
+		const notification = await db
+			.prepare(`SELECT count(*) as count FROM actor_notifications`)
+			.first<{ count: number }>()
+		assert.equal(notification?.count, 0)
 	})
 
 	test('ignore when trying to follow multiple times', async () => {

--- a/packages/backend/src/activitypub/activities/follow.test.ts
+++ b/packages/backend/src/activitypub/activities/follow.test.ts
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert/strict'
 import app from '@wildebeest/backend'
 import { Activity, FollowActivity } from '@wildebeest/backend/activitypub/activities'
 import * as activityHandler from '@wildebeest/backend/activitypub/activities/handle'
+import { type Actor } from '@wildebeest/backend/activitypub/actors'
 import { getApId } from '@wildebeest/backend/activitypub/objects'
 import { insertBlock } from '@wildebeest/backend/mastodon/block'
 import { acceptFollowing, addFollowing, isFollowingOrFollowingRequested } from '@wildebeest/backend/mastodon/follow'
@@ -14,18 +15,27 @@ const domain = 'cloudflare.com'
 const adminEmail = 'admin@example.com'
 const vapidKeys = {} as JWK
 
+function makeFollowActivity(follower: Pick<Actor, 'id'>, followee: Pick<Actor, 'id'>): FollowActivity {
+	return {
+		'@context': 'https://www.w3.org/ns/activitystreams',
+		id: createActivityId(domain),
+		type: 'Follow',
+		actor: follower.id,
+		object: followee.id,
+	}
+}
+
 describe('Follow', () => {
-	let receivedActivity: Activity | null = null
+	let receivedActivities: Activity[] = []
 
 	beforeEach(() => {
-		receivedActivity = null
+		receivedActivities = []
 
 		globalThis.fetch = async (input: RequestInfo) => {
 			const request = new Request(input)
 			if (request.url === `https://${domain}/ap/users/sven2/inbox`) {
 				assert.equal(request.method, 'POST')
-				const data = await request.json<Activity>()
-				receivedActivity = data
+				receivedActivities.push(await request.json<Activity>())
 				return new Response('')
 			}
 
@@ -38,13 +48,7 @@ describe('Follow', () => {
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 		const actor2 = await createTestUser(domain, db, userKEK, 'sven2@cloudflare.com')
 
-		const activity: Activity = {
-			'@context': 'https://www.w3.org/ns/activitystreams',
-			id: createActivityId(domain),
-			type: 'Follow',
-			actor: actor2.id,
-			object: actor.id,
-		}
+		const activity = makeFollowActivity(actor2, actor)
 
 		await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
 
@@ -59,7 +63,8 @@ describe('Follow', () => {
 		assert.equal(row.target_actor_id, actor.id.toString())
 		assert.equal(row.state, 'accepted')
 
-		assert(receivedActivity)
+		assert.equal(receivedActivities.length, 1)
+		const receivedActivity = receivedActivities[0]
 		assert.equal(receivedActivity.type, 'Accept')
 		assert.equal(getApId(receivedActivity.actor).toString(), actor.id.toString())
 		assert.equal(
@@ -145,13 +150,7 @@ describe('Follow', () => {
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 		const actor2 = await createTestUser(domain, db, userKEK, 'sven2@cloudflare.com')
 
-		const activity: Activity = {
-			'@context': 'https://www.w3.org/ns/activitystreams',
-			id: createActivityId(domain),
-			type: 'Follow',
-			actor: actor2.id,
-			object: actor.id,
-		}
+		const activity = makeFollowActivity(actor2, actor)
 
 		await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
 
@@ -172,17 +171,11 @@ describe('Follow', () => {
 		const actor2 = await createTestUser(domain, db, userKEK, 'blocked-follower@cloudflare.com')
 		await insertBlock(db, actor, actor2)
 
-		const activity: Activity = {
-			'@context': 'https://www.w3.org/ns/activitystreams',
-			id: createActivityId(domain),
-			type: 'Follow',
-			actor: actor2.id,
-			object: actor.id,
-		}
+		const activity = makeFollowActivity(actor2, actor)
 
 		await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
 
-		assert.equal(receivedActivity, null)
+		assert.equal(receivedActivities.length, 0)
 		assert.equal(await isFollowingOrFollowingRequested(db, actor2, actor), false)
 		const notification = await db
 			.prepare(`SELECT count(*) as count FROM actor_notifications`)
@@ -190,31 +183,24 @@ describe('Follow', () => {
 		assert.equal(notification?.count, 0)
 	})
 
-	test('ignore when trying to follow multiple times', async () => {
+	test('keeps one following row while accepting repeated follows', async () => {
 		const db = makeDB()
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 		const actor2 = await createTestUser(domain, db, userKEK, 'sven2@cloudflare.com')
 
-		const activity: Activity = {
-			'@context': 'https://www.w3.org/ns/activitystreams',
-			id: createActivityId(domain),
-			type: 'Follow',
-			actor: actor2.id,
-			object: actor.id,
+		const activity = makeFollowActivity(actor2, actor)
+
+		const repeatCount = 3
+		for (let i = 0; i < repeatCount; i++) {
+			await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
 		}
 
-		await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
-		await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
-		await activityHandler.handle(domain, activity, db, userKEK, adminEmail, vapidKeys)
-
-		// Even if we followed multiple times, only one row should be present.
-		const { count } = await db
-			.prepare(`SELECT count(*) as count FROM actor_following`)
+		const row = await db
+			.prepare(`SELECT count(*) as count FROM actor_following WHERE actor_id = ?1 AND target_actor_id = ?2`)
+			.bind(actor2.id.toString(), actor.id.toString())
 			.first<{ count: number }>()
-			.then((row) => {
-				assert.ok(row)
-				return row
-			})
-		assert.equal(count, 1)
+		assert.ok(row)
+		assert.equal(row.count, 1)
+		assert.equal(receivedActivities.length, repeatCount)
 	})
 })

--- a/packages/backend/src/activitypub/activities/follow.ts
+++ b/packages/backend/src/activitypub/activities/follow.ts
@@ -7,7 +7,7 @@ import { type ApObject, getApId } from '@wildebeest/backend/activitypub/objects'
 import { Database } from '@wildebeest/backend/database'
 import { getSigningKey } from '@wildebeest/backend/mastodon/account'
 import { hasBlockBetween } from '@wildebeest/backend/mastodon/block'
-import { addAcceptedFollowingIfNotBlocked } from '@wildebeest/backend/mastodon/follow'
+import { ensureAcceptedFollowingIfNotBlocked } from '@wildebeest/backend/mastodon/follow'
 import { insertFollowNotification, sendFollowNotification } from '@wildebeest/backend/mastodon/notification'
 import { actorToHandle } from '@wildebeest/backend/utils/handle'
 import { JWK } from '@wildebeest/backend/webpush/jwk'
@@ -56,7 +56,7 @@ export async function handleFollowActivity(
 		console.warn(`actor ${followerId} not found`)
 		return
 	}
-	if (!(await addAcceptedFollowingIfNotBlocked(domain, db, follower, followee))) {
+	if (!(await ensureAcceptedFollowingIfNotBlocked(domain, db, follower, followee))) {
 		return
 	}
 

--- a/packages/backend/src/activitypub/activities/follow.ts
+++ b/packages/backend/src/activitypub/activities/follow.ts
@@ -7,7 +7,7 @@ import { type ApObject, getApId } from '@wildebeest/backend/activitypub/objects'
 import { Database } from '@wildebeest/backend/database'
 import { getSigningKey } from '@wildebeest/backend/mastodon/account'
 import { hasBlockBetween } from '@wildebeest/backend/mastodon/block'
-import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
+import { addAcceptedFollowingIfNotBlocked } from '@wildebeest/backend/mastodon/follow'
 import { insertFollowNotification, sendFollowNotification } from '@wildebeest/backend/mastodon/notification'
 import { actorToHandle } from '@wildebeest/backend/utils/handle'
 import { JWK } from '@wildebeest/backend/webpush/jwk'
@@ -47,19 +47,20 @@ export async function handleFollowActivity(
 	}
 
 	const followerId = getApId(activity.actor)
+	if (await hasBlockBetween(db, { id: followerId }, followee)) {
+		return
+	}
+
 	const follower = await getAndCacheActor(followerId, db)
 	if (follower === null) {
 		console.warn(`actor ${followerId} not found`)
 		return
 	}
-	if (await hasBlockBetween(db, follower, followee)) {
+	if (!(await addAcceptedFollowingIfNotBlocked(domain, db, follower, followee))) {
 		return
 	}
 
-	await addFollowing(domain, db, follower, followee)
-
 	// Automatically send the Accept reply
-	await acceptFollowing(db, follower, followee)
 	const reply = await createAcceptActivity(db, domain, followee, activity)
 	const signingKey = await getSigningKey(userKEK, db, followee)
 	await deliverToActor(signingKey, followee, follower, reply, domain)

--- a/packages/backend/src/activitypub/activities/follow.ts
+++ b/packages/backend/src/activitypub/activities/follow.ts
@@ -6,6 +6,7 @@ import { deliverToActor } from '@wildebeest/backend/activitypub/deliver'
 import { type ApObject, getApId } from '@wildebeest/backend/activitypub/objects'
 import { Database } from '@wildebeest/backend/database'
 import { getSigningKey } from '@wildebeest/backend/mastodon/account'
+import { hasBlockBetween } from '@wildebeest/backend/mastodon/block'
 import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
 import { insertFollowNotification, sendFollowNotification } from '@wildebeest/backend/mastodon/notification'
 import { actorToHandle } from '@wildebeest/backend/utils/handle'
@@ -49,6 +50,9 @@ export async function handleFollowActivity(
 	const follower = await getAndCacheActor(followerId, db)
 	if (follower === null) {
 		console.warn(`actor ${followerId} not found`)
+		return
+	}
+	if (await hasBlockBetween(db, follower, followee)) {
 		return
 	}
 

--- a/packages/backend/src/mastodon/block.ts
+++ b/packages/backend/src/mastodon/block.ts
@@ -9,6 +9,7 @@ import {
 	getTargetMastodonIds,
 	insertAccountRelationship,
 } from './account_relationship'
+import { blockBetweenSql } from './block_sql'
 import { removeFollowing } from './follow'
 
 export async function insertBlock(db: Database, actor: Actor, target: Actor) {
@@ -47,11 +48,10 @@ export async function hasBlockBetween(
 		.prepare(
 			`SELECT 1
 FROM blocks
-WHERE (account_id = ? AND target_account_id = ?)
-   OR (account_id = ? AND target_account_id = ?)
+WHERE ${blockBetweenSql('?1', '?2')}
 LIMIT 1`
 		)
-		.bind(actorId, targetId, targetId, actorId)
+		.bind(actorId, targetId)
 		.first()
 	return row !== null
 }

--- a/packages/backend/src/mastodon/block.ts
+++ b/packages/backend/src/mastodon/block.ts
@@ -36,17 +36,24 @@ export function getBlockedByMastodonIds(db: Database, actor: Actor, targetIds: M
 	return getSourceMastodonIdsForTargets(db, 'blocks', actor, targetIds)
 }
 
-export async function hasBlockBetween(db: Database, actor: Actor, target: Actor): Promise<boolean> {
+export async function hasBlockBetween(
+	db: Database,
+	actor: Pick<Actor, 'id'>,
+	target: Pick<Actor, 'id'>
+): Promise<boolean> {
+	const actorId = actor.id.toString()
+	const targetId = target.id.toString()
 	const row = await db
 		.prepare(
-			`SELECT count(*) > 0 as blocked
+			`SELECT 1
 FROM blocks
 WHERE (account_id = ? AND target_account_id = ?)
-   OR (account_id = ? AND target_account_id = ?)`
+   OR (account_id = ? AND target_account_id = ?)
+LIMIT 1`
 		)
-		.bind(actor.id.toString(), target.id.toString(), target.id.toString(), actor.id.toString())
-		.first<{ blocked: 1 | 0 }>()
-	return row?.blocked === 1
+		.bind(actorId, targetId, targetId, actorId)
+		.first()
+	return row !== null
 }
 
 export function isSelfBlock(actor: Actor, target: Actor): boolean {

--- a/packages/backend/src/mastodon/block_sql.ts
+++ b/packages/backend/src/mastodon/block_sql.ts
@@ -1,0 +1,15 @@
+export function blockBetweenSql(accountIdExpression: string, targetAccountIdExpression: string): string {
+	return `
+	(account_id = ${accountIdExpression} AND target_account_id = ${targetAccountIdExpression})
+	OR (account_id = ${targetAccountIdExpression} AND target_account_id = ${accountIdExpression})
+	`
+}
+
+export function noBlockBetweenSql(accountIdExpression: string, targetAccountIdExpression: string): string {
+	return `
+	NOT EXISTS (
+		SELECT 1 FROM blocks
+		WHERE ${blockBetweenSql(accountIdExpression, targetAccountIdExpression)}
+	)
+	`
+}

--- a/packages/backend/src/mastodon/follow.ts
+++ b/packages/backend/src/mastodon/follow.ts
@@ -3,6 +3,7 @@ import { type Database } from '@wildebeest/backend/database'
 import { MastodonId } from '@wildebeest/backend/types'
 import { actorToAcct } from '@wildebeest/backend/utils/handle'
 
+import { noBlockBetweenSql } from './block_sql'
 import { assertBatchSuccess, getResultsField } from './utils'
 
 const STATE_PENDING = 'pending'
@@ -125,7 +126,7 @@ export async function addFollowing(
 	return id
 }
 
-export async function addAcceptedFollowingIfNotBlocked(
+export async function ensureAcceptedFollowingIfNotBlocked(
 	domain: string,
 	db: Database,
 	follower: Pick<Actor, 'id'>,
@@ -134,48 +135,41 @@ export async function addAcceptedFollowingIfNotBlocked(
 	const id = crypto.randomUUID()
 	const followerId = follower.id.toString()
 	const followeeId = followee.id.toString()
-	const optionValues = serializeFollowOptions({})
 
-	const results = await db.batch([
-		db
-			.prepare(
-				db.qb.insertOrIgnore(`
-			INTO actor_following (id, actor_id, target_actor_id, state, target_actor_acct, show_reblogs, notify, languages)
-			SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8
-			WHERE NOT EXISTS (
-				SELECT 1 FROM blocks
-				WHERE (account_id = ?2 AND target_account_id = ?3)
-				   OR (account_id = ?3 AND target_account_id = ?2)
-			)
-		`)
-			)
-			.bind(
-				id,
-				followerId,
-				followeeId,
-				STATE_ACCEPTED,
-				actorToAcct(followee, domain),
-				optionValues.showReblogs,
-				optionValues.notify,
-				optionValues.languages
-			),
-		db
-			.prepare(
-				`
-	UPDATE actors
-	SET interaction_count = interaction_count + 1
-	WHERE id = ?1
-	  AND NOT EXISTS (SELECT 1 FROM users WHERE users.actor_id = actors.id)
-	  AND EXISTS (
-	    SELECT 1 FROM actor_following
-	    WHERE id = ?2 AND actor_id = ?3 AND target_actor_id = ?1 AND state = ?4
-	  )
+	const out = await db
+		.prepare(
+			`
+	INSERT INTO actor_following (id, actor_id, target_actor_id, state, target_actor_acct)
+	SELECT ?1, ?2, ?3, ?4, ?5
+	WHERE ${noBlockBetweenSql('?2', '?3')}
+	ON CONFLICT(actor_id, target_actor_id) DO UPDATE SET state = excluded.state
+	WHERE actor_following.state = ?6
 	`
-			)
-			.bind(followeeId, id, followerId, STATE_ACCEPTED),
-	])
-	assertBatchSuccess(results)
-	return results[0].meta.changes === 1
+		)
+		.bind(id, followerId, followeeId, STATE_ACCEPTED, actorToAcct(followee, domain), STATE_PENDING)
+		.run()
+	if (!out.success) {
+		throw new Error('SQL error: ' + out.error)
+	}
+	if (out.meta.changes === 1) {
+		return true
+	}
+
+	const acceptedFollow = await db
+		.prepare(
+			`
+		SELECT 1
+		FROM actor_following
+		WHERE actor_id = ?1
+		  AND target_actor_id = ?2
+		  AND state = ?3
+		  AND ${noBlockBetweenSql('?1', '?2')}
+		LIMIT 1
+		`
+		)
+		.bind(followerId, followeeId, STATE_ACCEPTED)
+		.first()
+	return acceptedFollow !== null
 }
 
 export async function updateFollowingOptions(

--- a/packages/backend/src/mastodon/follow.ts
+++ b/packages/backend/src/mastodon/follow.ts
@@ -125,6 +125,59 @@ export async function addFollowing(
 	return id
 }
 
+export async function addAcceptedFollowingIfNotBlocked(
+	domain: string,
+	db: Database,
+	follower: Pick<Actor, 'id'>,
+	followee: Pick<Actor, 'id' | 'preferredUsername'>
+): Promise<boolean> {
+	const id = crypto.randomUUID()
+	const followerId = follower.id.toString()
+	const followeeId = followee.id.toString()
+	const optionValues = serializeFollowOptions({})
+
+	const results = await db.batch([
+		db
+			.prepare(
+				db.qb.insertOrIgnore(`
+			INTO actor_following (id, actor_id, target_actor_id, state, target_actor_acct, show_reblogs, notify, languages)
+			SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8
+			WHERE NOT EXISTS (
+				SELECT 1 FROM blocks
+				WHERE (account_id = ?2 AND target_account_id = ?3)
+				   OR (account_id = ?3 AND target_account_id = ?2)
+			)
+		`)
+			)
+			.bind(
+				id,
+				followerId,
+				followeeId,
+				STATE_ACCEPTED,
+				actorToAcct(followee, domain),
+				optionValues.showReblogs,
+				optionValues.notify,
+				optionValues.languages
+			),
+		db
+			.prepare(
+				`
+	UPDATE actors
+	SET interaction_count = interaction_count + 1
+	WHERE id = ?1
+	  AND NOT EXISTS (SELECT 1 FROM users WHERE users.actor_id = actors.id)
+	  AND EXISTS (
+	    SELECT 1 FROM actor_following
+	    WHERE id = ?2 AND actor_id = ?3 AND target_actor_id = ?1 AND state = ?4
+	  )
+	`
+			)
+			.bind(followeeId, id, followerId, STATE_ACCEPTED),
+	])
+	assertBatchSuccess(results)
+	return results[0].meta.changes === 1
+}
+
 export async function updateFollowingOptions(
 	db: Database,
 	follower: Pick<Actor, 'id'>,

--- a/packages/backend/src/mastodon/timeline.test.ts
+++ b/packages/backend/src/mastodon/timeline.test.ts
@@ -2,10 +2,13 @@ import { strict as assert } from 'node:assert/strict'
 
 import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import { createAnnounceActivity } from '@wildebeest/backend/activitypub/activities/announce'
+import { insertBlock } from '@wildebeest/backend/mastodon/block'
+import { insertBookmark } from '@wildebeest/backend/mastodon/bookmark'
 import { acceptFollowing, addFollowing } from '@wildebeest/backend/mastodon/follow'
 import { insertHashtags } from '@wildebeest/backend/mastodon/hashtag'
 import { insertLike } from '@wildebeest/backend/mastodon/like'
-import { createReblog } from '@wildebeest/backend/mastodon/reblog'
+import { insertMute } from '@wildebeest/backend/mastodon/mute'
+import { createReblog, deleteReblog } from '@wildebeest/backend/mastodon/reblog'
 import {
 	LocalPreference,
 	getHomeTimeline,
@@ -64,6 +67,39 @@ describe('mastodon/timeline', () => {
 		assert.equal(data[2].account.username, 'sven2')
 		assert.equal(data[2].favourites_count, 1)
 		assert.equal(data[2].reblogs_count, 1)
+
+		await deleteReblog(db, actor, firstNoteFromActor2)
+		const dataAfterUnreblog = await getHomeTimeline(domain, db, connectedActor)
+		assert.equal(dataAfterUnreblog.length, 2)
+		assert.equal(dataAfterUnreblog[1].reblogs_count, 0)
+	})
+
+	test('home and list timelines hide blocked and muted accounts', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'filter-owner@cloudflare.com')
+		const blocked = await createTestUser(domain, db, userKEK, 'filter-blocked@cloudflare.com')
+		const muted = await createTestUser(domain, db, userKEK, 'filter-muted@cloudflare.com')
+		const visible = await createTestUser(domain, db, userKEK, 'filter-visible@cloudflare.com')
+
+		for (const target of [blocked, muted, visible]) {
+			await addFollowing(domain, db, actor, target)
+			await acceptFollowing(db, actor, target)
+			await createPublicStatus(domain, db, target, `post from ${target.preferredUsername}`)
+		}
+		await insertBlock(db, actor, blocked)
+		await insertMute(db, actor, muted)
+
+		const home = await getHomeTimeline(domain, db, actor)
+		assert.equal(home.length, 1)
+		assert.equal(home[0].account.username, 'filter-visible')
+
+		const list = await getListTimeline(domain, db, actor, [
+			blocked.id.toString(),
+			muted.id.toString(),
+			visible.id.toString(),
+		])
+		assert.equal(list.length, 1)
+		assert.equal(list[0].account.username, 'filter-visible')
 	})
 
 	test("home doesn't show private Notes from followed actors", async () => {
@@ -194,6 +230,25 @@ describe('mastodon/timeline', () => {
 		const data = await getHomeTimeline(domain, db, connectedActor)
 		assert.equal(data.length, 1)
 		assert.equal(data[0].favourited, true)
+	})
+
+	test('show status bookmarked in home and list timelines', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'bookmark-owner@cloudflare.com')
+		const member = await createTestUser(domain, db, userKEK, 'bookmark-member@cloudflare.com')
+
+		await addFollowing(domain, db, actor, member)
+		await acceptFollowing(db, actor, member)
+		const note = await createPublicStatus(domain, db, member, 'bookmarked post')
+		await insertBookmark(db, actor, note)
+
+		const home = await getHomeTimeline(domain, db, actor)
+		assert.equal(home.length, 1)
+		assert.equal(home[0].bookmarked, true)
+
+		const list = await getListTimeline(domain, db, actor, [member.id.toString()])
+		assert.equal(list.length, 1)
+		assert.equal(list[0].bookmarked, true)
 	})
 
 	test('show reblogs as independent notes', async () => {

--- a/packages/backend/src/mastodon/timeline.ts
+++ b/packages/backend/src/mastodon/timeline.ts
@@ -73,11 +73,12 @@ SELECT
   outbox_objects.cc as publisher_cc,
 
   (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
-  (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
-  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count,
+  COALESCE(objects.reblogs_count, 0) as reblogs_count,
+  COALESCE(objects.replies_count, 0) as replies_count,
 
   (SELECT count(*) > 0 FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id AND actor_reblogs.actor_id=?1) as reblogged,
   (SELECT count(*) > 0 FROM actor_favourites WHERE actor_favourites.object_id=objects.id AND actor_favourites.actor_id=?1) as favourited,
+  (SELECT count(*) > 0 FROM bookmarks WHERE bookmarks.status_id=objects.id AND bookmarks.account_id=?1) as bookmarked,
 
   actor_reblogs.id as reblog_id,
   actor_reblogs.mastodon_id as reblog_mastodon_id
@@ -88,6 +89,18 @@ FROM outbox_objects
 WHERE
   objects.type = 'Note'
   AND outbox_objects.actor_id IN ${db.qb.set('?2')}
+  AND NOT EXISTS (
+    SELECT 1 FROM blocks
+    WHERE blocks.account_id = ?1 AND blocks.target_account_id IN (outbox_objects.actor_id, objects.original_actor_id)
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM blocks
+    WHERE blocks.target_account_id = ?1 AND blocks.account_id IN (outbox_objects.actor_id, objects.original_actor_id)
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM mutes
+    WHERE mutes.account_id = ?1 AND mutes.target_account_id IN (outbox_objects.actor_id, objects.original_actor_id)
+  )
   AND (${db.qb.jsonExtractIsNull('objects.properties', 'inReplyTo')}
         OR ${db.qb.jsonExtract('objects.properties', 'inReplyTo')}
           IN (SELECT ifnull(objects.original_object_id, objects.id)
@@ -135,6 +148,7 @@ LIMIT ?4
 
 				reblogged: 1 | 0
 				favourited: 1 | 0
+				bookmarked: 1 | 0
 			} & ({ reblog_id: string; reblog_mastodon_id: string } | { reblog_id: null; reblog_mastodon_id: null })
 		>()
 	if (!success) {
@@ -193,8 +207,8 @@ SELECT
   outbox_objects.cc as publisher_cc,
 
   (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
-  (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
-  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count,
+  COALESCE(objects.reblogs_count, 0) as reblogs_count,
+  COALESCE(objects.replies_count, 0) as replies_count,
 
   actor_reblogs.id as reblog_id,
   actor_reblogs.mastodon_id as reblog_mastodon_id
@@ -332,11 +346,12 @@ SELECT
   outbox_objects.cc as publisher_cc,
 
   (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
-  (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
-  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count,
+  COALESCE(objects.reblogs_count, 0) as reblogs_count,
+  COALESCE(objects.replies_count, 0) as replies_count,
 
   (SELECT count(*) > 0 FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id AND actor_reblogs.actor_id=?1) as reblogged,
   (SELECT count(*) > 0 FROM actor_favourites WHERE actor_favourites.object_id=objects.id AND actor_favourites.actor_id=?1) as favourited,
+  (SELECT count(*) > 0 FROM bookmarks WHERE bookmarks.status_id=objects.id AND bookmarks.account_id=?1) as bookmarked,
 
   actor_reblogs.id as reblog_id,
   actor_reblogs.mastodon_id as reblog_mastodon_id
@@ -347,6 +362,18 @@ FROM outbox_objects
 WHERE
   objects.type = 'Note'
   AND outbox_objects.actor_id IN ${db.qb.set('?2')}
+  AND NOT EXISTS (
+    SELECT 1 FROM blocks
+    WHERE blocks.account_id = ?1 AND blocks.target_account_id IN (outbox_objects.actor_id, objects.original_actor_id)
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM blocks
+    WHERE blocks.target_account_id = ?1 AND blocks.account_id IN (outbox_objects.actor_id, objects.original_actor_id)
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM mutes
+    WHERE mutes.account_id = ?1 AND mutes.target_account_id IN (outbox_objects.actor_id, objects.original_actor_id)
+  )
   AND (${db.qb.jsonExtractIsNull('objects.properties', 'inReplyTo')}
         OR ${db.qb.jsonExtract('objects.properties', 'inReplyTo')}
           IN (SELECT ifnull(objects.original_object_id, objects.id)
@@ -388,6 +415,7 @@ LIMIT ?4
 
 				reblogged: 1 | 0
 				favourited: 1 | 0
+				bookmarked: 1 | 0
 			} & ({ reblog_id: string; reblog_mastodon_id: string } | { reblog_id: null; reblog_mastodon_id: null })
 		>()
 	if (!success) {

--- a/packages/backend/src/routes/api/v1/accounts/[id]/statuses.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/statuses.test.ts
@@ -150,14 +150,14 @@ describe('/api/v1/accounts/[id]/statuses', () => {
 		})
 		await insertBlock(db, viewer, blocked)
 		await insertMute(db, viewer, muted)
-		await insertMute(db, viewer, reblogger)
 
 		const req = new Request(`https://${domain}/api/v1/accounts/${reblogger[mastodonIdSymbol]}/statuses`)
 		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: viewer } })
 		await assertStatus(res, 200)
 
-		const data = await res.json<unknown[]>()
-		assert.deepEqual(data, [])
+		const data = await res.json<Array<{ reblog: { content: string } | null }>>()
+		assert.equal(data.length, 1)
+		assert.equal(data[0].reblog?.content, '<p>visible boosted status</p>')
 	})
 
 	test("get local actor statuses doesn't include replies", async () => {

--- a/packages/backend/src/routes/api/v1/accounts/[id]/statuses.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/statuses.test.ts
@@ -13,7 +13,10 @@ import { addObjectInOutbox, get } from '@wildebeest/backend/activitypub/actors/o
 import { getApId, getObjectById, mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
 import { createImage } from '@wildebeest/backend/activitypub/objects/image'
 import { isNote, Note } from '@wildebeest/backend/activitypub/objects/note'
+import { insertBlock } from '@wildebeest/backend/mastodon/block'
+import { insertBookmark } from '@wildebeest/backend/mastodon/bookmark'
 import { insertLike } from '@wildebeest/backend/mastodon/like'
+import { insertMute } from '@wildebeest/backend/mastodon/mute'
 import { createReblog } from '@wildebeest/backend/mastodon/reblog'
 import { createPublicStatus, createReply } from '@wildebeest/backend/test/shared.utils'
 import { makeDB, createTestUser, assertStatus } from '@wildebeest/backend/test/utils'
@@ -73,6 +76,88 @@ describe('/api/v1/accounts/[id]/statuses', () => {
 		assert.equal(data[2].content, '<p>my first status</p>')
 		assert.equal(data[2].favourites_count, 1)
 		assert.equal(data[2].reblogs_count, 0)
+	})
+
+	test('get local actor statuses includes authenticated viewer state', async () => {
+		const db = makeDB()
+		const author = await createTestUser(domain, db, userKEK, 'viewer-state-author@cloudflare.com')
+		const viewer = await createTestUser(domain, db, userKEK, 'viewer-state-viewer@cloudflare.com')
+		const firstNote = await createPublicStatus(domain, db, author, 'viewer state first')
+		await sleep(5)
+		const secondNote = await createPublicStatus(domain, db, author, 'viewer state second')
+		await sleep(5)
+		await createReblog(db, author, secondNote, {
+			to: [PUBLIC_GROUP],
+			cc: [],
+			id: 'https://example.com/viewer-state-boost',
+		})
+		await insertLike(db, viewer, firstNote)
+		await insertBookmark(db, viewer, firstNote)
+		await createReblog(db, viewer, secondNote, {
+			to: [PUBLIC_GROUP],
+			cc: [],
+			id: 'https://example.com/viewer-state-viewer-boost',
+		})
+
+		const req = new Request(`https://${domain}/api/v1/accounts/${author[mastodonIdSymbol]}/statuses`)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: viewer } })
+		await assertStatus(res, 200)
+
+		const data = await res.json<
+			{
+				content: string
+				favourited: boolean
+				reblogged: boolean
+				bookmarked: boolean
+				reblog: null | { content: string; favourited: boolean; reblogged: boolean; bookmarked: boolean }
+			}[]
+		>()
+		const first = data.find((status) => status.content === '<p>viewer state first</p>')
+		assert.ok(first)
+		assert.equal(first.favourited, true)
+		assert.equal(first.bookmarked, true)
+
+		const second = data.find((status) => status.content === '<p>viewer state second</p>')
+		assert.ok(second)
+		assert.equal(second.reblogged, true)
+
+		const boost = data.find((status) => status.reblog !== null)
+		assert.ok(boost?.reblog)
+		assert.equal(boost.reblog.reblogged, true)
+	})
+
+	test('get local actor statuses filters blocked or muted boosted authors', async () => {
+		const db = makeDB()
+		const viewer = await createTestUser(domain, db, userKEK, 'viewer-filter@cloudflare.com')
+		const reblogger = await createTestUser(domain, db, userKEK, 'reblogger-filter@cloudflare.com')
+		const blocked = await createTestUser(domain, db, userKEK, 'blocked-filter@cloudflare.com')
+		const muted = await createTestUser(domain, db, userKEK, 'muted-filter@cloudflare.com')
+		const visible = await createTestUser(domain, db, userKEK, 'visible-filter@cloudflare.com')
+		const blockedNote = await createPublicStatus(domain, db, blocked, 'blocked boosted status')
+		const mutedNote = await createPublicStatus(domain, db, muted, 'muted boosted status')
+		const visibleNote = await createPublicStatus(domain, db, visible, 'visible boosted status')
+
+		await createReblog(db, reblogger, blockedNote, {
+			to: [PUBLIC_GROUP],
+			cc: [],
+			id: 'https://example.com/blocked-boost',
+		})
+		await createReblog(db, reblogger, mutedNote, { to: [PUBLIC_GROUP], cc: [], id: 'https://example.com/muted-boost' })
+		await createReblog(db, reblogger, visibleNote, {
+			to: [PUBLIC_GROUP],
+			cc: [],
+			id: 'https://example.com/visible-boost',
+		})
+		await insertBlock(db, viewer, blocked)
+		await insertMute(db, viewer, muted)
+		await insertMute(db, viewer, reblogger)
+
+		const req = new Request(`https://${domain}/api/v1/accounts/${reblogger[mastodonIdSymbol]}/statuses`)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: viewer } })
+		await assertStatus(res, 200)
+
+		const data = await res.json<unknown[]>()
+		assert.deepEqual(data, [])
 	})
 
 	test("get local actor statuses doesn't include replies", async () => {

--- a/packages/backend/src/routes/api/v1/accounts/[id]/statuses.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/statuses.ts
@@ -7,6 +7,7 @@ import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import { Actor, getActorByMastodonId, Person } from '@wildebeest/backend/activitypub/actors'
 import { type Database, getDatabase } from '@wildebeest/backend/database'
 import { resourceNotFound } from '@wildebeest/backend/errors'
+import { hasBlockBetween } from '@wildebeest/backend/mastodon/block'
 import { isFollowing } from '@wildebeest/backend/mastodon/follow'
 import { toMastodonStatusesFromRowsWithActor } from '@wildebeest/backend/mastodon/status'
 import { getStatusRange } from '@wildebeest/backend/mastodon/timeline'
@@ -88,6 +89,9 @@ async function getStatuses(
 		// to avoid returning statuses that aren't pinned.
 		return new Response(JSON.stringify([]), { headers })
 	}
+	if (connectedActor && (await hasBlockBetween(db, connectedActor, actor))) {
+		return new Response(JSON.stringify([]), { headers })
+	}
 
 	// Client asked to retrieve statuses using max_id or (max_id and since_id) or min_id
 	// As opposed to Mastodon we don't use incremental ID but UUID, we need
@@ -111,6 +115,14 @@ async function getStatuses(
 		}
 	}
 
+	const bindings =
+		max && min
+			? [actor.id.toString(), JSON.stringify(targets), max, params.limit, min]
+			: [actor.id.toString(), JSON.stringify(targets), max ?? db.qb.epoch(), params.limit]
+	if (connectedActor) {
+		bindings.push(connectedActor.id.toString())
+	}
+	const viewerParam = max && min ? '?6' : '?5'
 	const { success, error, results } = await db
 		.prepare(
 			`
@@ -126,8 +138,11 @@ SELECT
   outbox_objects.cc as publisher_cc,
 
   (SELECT count(*) FROM actor_favourites WHERE actor_favourites.object_id=objects.id) as favourites_count,
-  (SELECT count(*) FROM actor_reblogs WHERE actor_reblogs.object_id=objects.id) as reblogs_count,
-  (SELECT count(*) FROM actor_replies WHERE actor_replies.in_reply_to_object_id=objects.id) as replies_count,
+  COALESCE(objects.reblogs_count, 0) as reblogs_count,
+  COALESCE(objects.replies_count, 0) as replies_count,
+  ${connectedActor ? `(SELECT count(*) > 0 FROM actor_reblogs WHERE actor_reblogs.object_id = objects.id AND actor_reblogs.actor_id = ${viewerParam})` : '0'} as reblogged,
+  ${connectedActor ? `(SELECT count(*) > 0 FROM actor_favourites WHERE actor_favourites.object_id = objects.id AND actor_favourites.actor_id = ${viewerParam})` : '0'} as favourited,
+  ${connectedActor ? `(SELECT count(*) > 0 FROM bookmarks WHERE bookmarks.status_id = objects.id AND bookmarks.account_id = ${viewerParam})` : '0'} as bookmarked,
 
   actor_reblogs.id as reblog_id,
 	actor_reblogs.mastodon_id as reblog_mastodon_id
@@ -143,18 +158,29 @@ WHERE
   AND ${db.qb.timeNormalize('outbox_objects.cdate')} ${max ? '<' : '>'} ?3
   ${max && min ? 'AND ' + db.qb.timeNormalize('outbox_objects.cdate') + ' > ?5' : ''}
   ${params.exclude_reblogs ? 'AND actor_reblogs.id IS NULL' : ''}
+  ${
+		connectedActor
+			? `AND NOT EXISTS (
+    SELECT 1 FROM blocks
+    WHERE blocks.account_id = ${viewerParam} AND blocks.target_account_id = objects.original_actor_id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM blocks
+    WHERE blocks.target_account_id = ${viewerParam} AND blocks.account_id = objects.original_actor_id
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM mutes
+    WHERE mutes.account_id = ${viewerParam}
+      AND mutes.target_account_id IN (outbox_objects.actor_id, objects.original_actor_id)
+  )`
+			: ''
+	}
   ${params.only_media ? `AND ${db.qb.jsonArrayLength(db.qb.jsonExtract('objects.properties', 'attachment'))} != 0` : ''}
 ORDER BY ${db.qb.timeNormalize('outbox_objects.published_date')} DESC
 LIMIT ?4
   `
 		)
-		.bind(
-			...(max && min
-				? [actor.id.toString(), JSON.stringify(targets), max, params.limit, min]
-				: min
-					? [actor.id.toString(), JSON.stringify(targets), max ?? db.qb.epoch(), params.limit, min]
-					: [actor.id.toString(), JSON.stringify(targets), max ?? db.qb.epoch(), params.limit])
-		)
+		.bind(...bindings)
 		.all<{
 			id: string
 			mastodon_id: string
@@ -169,6 +195,9 @@ LIMIT ?4
 			favourites_count: number
 			reblogs_count: number
 			replies_count: number
+			reblogged: 1 | 0
+			favourited: 1 | 0
+			bookmarked: 1 | 0
 
 			reblog_id: string | null
 			reblog_mastodon_id: string | null

--- a/packages/backend/src/routes/api/v1/statuses/[id].test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id].test.ts
@@ -4,6 +4,7 @@ import app from '@wildebeest/backend'
 import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
 import { createImage } from '@wildebeest/backend/activitypub/objects/image'
+import { insertBlock } from '@wildebeest/backend/mastodon/block'
 import { insertBookmark } from '@wildebeest/backend/mastodon/bookmark'
 import { addFollowing, acceptFollowing } from '@wildebeest/backend/mastodon/follow'
 import { insertLike } from '@wildebeest/backend/mastodon/like'
@@ -142,6 +143,41 @@ describe('/api/v1/statuses/[id]', () => {
 		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}`)
 		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: recipient } })
 		await assertStatus(res, 200)
+	})
+
+	test('get private status as non-follower returns 404', async () => {
+		const db = makeDB()
+		const author = await createTestUser(domain, db, userKEK, 'private-denied-author@cloudflare.com')
+		const viewer = await createTestUser(domain, db, userKEK, 'private-denied-viewer@cloudflare.com')
+		const note = await createPrivateStatus(domain, db, author, 'private denied status')
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}`)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: viewer } })
+		await assertStatus(res, 404)
+	})
+
+	test('get direct status as non-recipient returns 404', async () => {
+		const db = makeDB()
+		const author = await createTestUser(domain, db, userKEK, 'direct-denied-author@cloudflare.com')
+		const recipient = await createTestUser(domain, db, userKEK, 'direct-denied-recipient@cloudflare.com')
+		const viewer = await createTestUser(domain, db, userKEK, 'direct-denied-viewer@cloudflare.com')
+		const note = await createDirectStatus(domain, db, author, 'direct denied status', [], { to: [recipient] })
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}`)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: viewer } })
+		await assertStatus(res, 404)
+	})
+
+	test('get status as blocked viewer returns 404', async () => {
+		const db = makeDB()
+		const author = await createTestUser(domain, db, userKEK, 'blocked-status-author@cloudflare.com')
+		const viewer = await createTestUser(domain, db, userKEK, 'blocked-status-viewer@cloudflare.com')
+		const note = await createPublicStatus(domain, db, author, 'blocked status')
+		await insertBlock(db, author, viewer)
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}`)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: viewer } })
+		await assertStatus(res, 404)
 	})
 
 	test('update non-existing status', async () => {

--- a/packages/backend/src/routes/api/v1/statuses/[id].test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id].test.ts
@@ -4,10 +4,17 @@ import app from '@wildebeest/backend'
 import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
 import { createImage } from '@wildebeest/backend/activitypub/objects/image'
+import { insertBookmark } from '@wildebeest/backend/mastodon/bookmark'
 import { addFollowing, acceptFollowing } from '@wildebeest/backend/mastodon/follow'
 import { insertLike } from '@wildebeest/backend/mastodon/like'
 import { createReblog } from '@wildebeest/backend/mastodon/reblog'
-import { createPublicStatus } from '@wildebeest/backend/test/shared.utils'
+import { insertReply } from '@wildebeest/backend/mastodon/reply'
+import {
+	createDirectStatus,
+	createPrivateStatus,
+	createPublicStatus,
+	createReply,
+} from '@wildebeest/backend/test/shared.utils'
 import { makeDB, createTestUser, assertStatus, makeCache, makeQueue, makeDOCache } from '@wildebeest/backend/test/utils'
 import { MastodonStatus } from '@wildebeest/backend/types'
 
@@ -31,6 +38,22 @@ describe('/api/v1/statuses/[id]', () => {
 
 		const data = await res.json<{ favourites_count: unknown }>()
 		assert.equal(data.favourites_count, 2)
+	})
+
+	test('get status count replies', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'reply-parent@cloudflare.com')
+		const actor2 = await createTestUser(domain, db, userKEK, 'reply-child@cloudflare.com')
+		const note = await createPublicStatus(domain, db, actor, 'parent status')
+
+		await createReply(domain, db, actor2, note, '@reply-parent@cloudflare.com child reply')
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}`)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: actor } })
+		await assertStatus(res, 200)
+
+		const data = await res.json<{ replies_count: unknown }>()
+		assert.equal(data.replies_count, 1)
 	})
 
 	test('get status with image', async () => {
@@ -76,6 +99,49 @@ describe('/api/v1/statuses/[id]', () => {
 
 		const data = await res.json<{ reblogs_count: unknown }>()
 		assert.equal(data.reblogs_count, 2)
+	})
+
+	test('get status includes viewer state', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'viewer-state@cloudflare.com')
+		const note = await createPublicStatus(domain, db, actor, 'viewer state status')
+
+		await insertLike(db, actor, note)
+		await insertBookmark(db, actor, note)
+		await createReblog(db, actor, note, { to: [PUBLIC_GROUP], cc: [], id: 'https://example.com/viewer-state-reblog' })
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}`)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: actor } })
+		await assertStatus(res, 200)
+
+		const data = await res.json<{ favourited: boolean; reblogged: boolean; bookmarked: boolean }>()
+		assert.equal(data.favourited, true)
+		assert.equal(data.reblogged, true)
+		assert.equal(data.bookmarked, true)
+	})
+
+	test('get private status as follower', async () => {
+		const db = makeDB()
+		const author = await createTestUser(domain, db, userKEK, 'private-status-author@cloudflare.com')
+		const follower = await createTestUser(domain, db, userKEK, 'private-status-follower@cloudflare.com')
+		await addFollowing(domain, db, follower, author)
+		await acceptFollowing(db, follower, author)
+		const note = await createPrivateStatus(domain, db, author, 'private status')
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}`)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: follower } })
+		await assertStatus(res, 200)
+	})
+
+	test('get direct status as recipient', async () => {
+		const db = makeDB()
+		const author = await createTestUser(domain, db, userKEK, 'direct-status-author@cloudflare.com')
+		const recipient = await createTestUser(domain, db, userKEK, 'direct-status-recipient@cloudflare.com')
+		const note = await createDirectStatus(domain, db, author, 'direct status', [], { to: [recipient] })
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}`)
+		const res = await app.fetch(req, { DATABASE: db, data: { connectedActor: recipient } })
+		await assertStatus(res, 200)
 	})
 
 	test('update non-existing status', async () => {
@@ -342,6 +408,79 @@ describe('/api/v1/statuses/[id]', () => {
 			const row = await db.prepare(`SELECT count(*) as count FROM objects`).first<{ count: number }>()
 			assert.equal(row?.count, 0)
 		}
+	})
+
+	test('insertReply repairs stale reply parent row and counts', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'reply-repair@cloudflare.com')
+		const oldParent = await createPublicStatus(domain, db, actor, 'old parent')
+		const newParent = await createPublicStatus(domain, db, actor, 'new parent')
+		const reply = await createReply(domain, db, actor, oldParent, '@reply-repair@cloudflare.com reply')
+
+		await insertReply(db, actor, reply, newParent)
+
+		const replyRow = await db
+			.prepare('SELECT in_reply_to_id FROM objects WHERE id = ?')
+			.bind(reply.id.toString())
+			.first<{ in_reply_to_id: string }>()
+		assert.equal(replyRow?.in_reply_to_id, newParent.id.toString())
+
+		const actorReply = await db
+			.prepare('SELECT in_reply_to_object_id FROM actor_replies WHERE object_id = ?')
+			.bind(reply.id.toString())
+			.first<{ in_reply_to_object_id: string }>()
+		assert.equal(actorReply?.in_reply_to_object_id, newParent.id.toString())
+
+		const oldCount = await db
+			.prepare('SELECT replies_count FROM objects WHERE id = ?')
+			.bind(oldParent.id.toString())
+			.first<{ replies_count: number }>()
+		assert.equal(oldCount?.replies_count, 0)
+		const newCount = await db
+			.prepare('SELECT replies_count FROM objects WHERE id = ?')
+			.bind(newParent.id.toString())
+			.first<{ replies_count: number }>()
+		assert.equal(newCount?.replies_count, 1)
+	})
+
+	test('delete reply decrements parent replies count', async () => {
+		const db = makeDB()
+		const queue = makeQueue()
+		const doCache = makeDOCache()
+
+		const actor = await createTestUser(domain, db, userKEK, 'reply-deleter@cloudflare.com')
+		const note = await createPublicStatus(domain, db, actor, 'parent status')
+		const reply = await createReply(domain, db, actor, note, '@reply-deleter@cloudflare.com reply')
+		const replyRow = await db
+			.prepare('SELECT in_reply_to_id, in_reply_to_account_id FROM objects WHERE id=?')
+			.bind(reply.id.toString())
+			.first<{ in_reply_to_id: string | null; in_reply_to_account_id: string | null }>()
+		assert.equal(replyRow?.in_reply_to_id, note.id.toString())
+		assert.equal(replyRow?.in_reply_to_account_id, actor.id.toString())
+
+		{
+			const row = await db
+				.prepare('SELECT replies_count FROM objects WHERE id=?')
+				.bind(note.id.toString())
+				.first<{ replies_count: number }>()
+			assert.equal(row?.replies_count, 1)
+		}
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${reply[mastodonIdSymbol]}`, { method: 'DELETE' })
+		const res = await app.fetch(req, {
+			DATABASE: db,
+			userKEK,
+			QUEUE: queue,
+			DO_CACHE: doCache,
+			data: { connectedActor: actor },
+		})
+		await assertStatus(res, 200)
+
+		const row = await db
+			.prepare('SELECT replies_count FROM objects WHERE id=?')
+			.bind(note.id.toString())
+			.first<{ replies_count: number }>()
+		assert.equal(row?.replies_count, 0)
 	})
 
 	test('delete status regenerates the timeline', async () => {

--- a/packages/backend/src/routes/api/v1/statuses/[id].ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id].ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 import { createDeleteActivity } from '@wildebeest/backend/activitypub/activities/delete'
 import { createUpdateActivity } from '@wildebeest/backend/activitypub/activities/update'
-import type { Person } from '@wildebeest/backend/activitypub/actors'
+import { type Person } from '@wildebeest/backend/activitypub/actors'
 import { deliverFollowers } from '@wildebeest/backend/activitypub/deliver'
 import { deleteObject, getObjectByMastodonId, originalActorIdSymbol } from '@wildebeest/backend/activitypub/objects'
 import { Image, isImage } from '@wildebeest/backend/activitypub/objects/image'
@@ -16,16 +16,16 @@ import { type Database, getDatabase } from '@wildebeest/backend/database'
 import * as errors from '@wildebeest/backend/errors'
 import { enrichStatus } from '@wildebeest/backend/mastodon/microformats'
 import {
-	getMastodonStatusById,
+	canViewStatus,
 	getMentions,
 	MAX_MEDIA_ATTACHMENTS,
 	MAX_STATUS_LENGTH,
+	setMastodonStatusViewerState,
 	toMastodonStatusFromObject,
 } from '@wildebeest/backend/mastodon/status'
 import * as timeline from '@wildebeest/backend/mastodon/timeline'
 import type { DeliverMessageBody, HonoEnv, MastodonId, Queue } from '@wildebeest/backend/types'
 import { cors, readBody } from '@wildebeest/backend/utils'
-import { actorToAcct } from '@wildebeest/backend/utils/handle'
 import myz from '@wildebeest/backend/utils/zod'
 
 const headers = {
@@ -111,18 +111,22 @@ async function handleRequestGet(
 	domain: string,
 	connectedActor: Person | null
 ): Promise<Response> {
-	const status = await getMastodonStatusById(db, id, domain)
+	const obj = await getObjectByMastodonId<Note>(domain, db, id)
+	if (obj === null) {
+		return new Response('', { status: 404 })
+	}
+	const status = await toMastodonStatusFromObject(db, obj, domain)
 	if (status === null) {
 		return new Response('', { status: 404 })
 	}
 
-	if (status.visibility === 'public' || status.visibility === 'unlisted') {
-		return new Response(JSON.stringify(status), { headers })
+	if (!(await canViewStatus(db, obj, connectedActor ?? undefined))) {
+		return new Response('', { status: 404 })
+	}
+	if (connectedActor) {
+		await setMastodonStatusViewerState(db, status, obj, connectedActor)
 	}
 
-	if (!connectedActor || status.account.acct !== actorToAcct(connectedActor, domain)) {
-		return errors.notAuthorized('status is private')
-	}
 	return new Response(JSON.stringify(status), { headers })
 }
 

--- a/packages/backend/src/routes/api/v1/statuses/[id]/context.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/context.test.ts
@@ -1,7 +1,9 @@
 import { strict as assert } from 'node:assert/strict'
 
 import app from '@wildebeest/backend'
+import { PUBLIC_GROUP } from '@wildebeest/backend/activitypub/activities'
 import { mastodonIdSymbol } from '@wildebeest/backend/activitypub/objects'
+import { createReblog } from '@wildebeest/backend/mastodon/reblog'
 import { createPublicStatus, createReply } from '@wildebeest/backend/test/shared.utils'
 import { makeDB, createTestUser, assertStatus } from '@wildebeest/backend/test/utils'
 
@@ -30,5 +32,28 @@ describe('/api/v1/statuses/[id]/context', () => {
 			data.descendants[0].content,
 			'<p><span class="h-card"><a href="https://cloudflare.com/@sven" class="u-url mention">@<span>sven</span></a></span> a reply</p>'
 		)
+	})
+
+	test('status context does not duplicate reblogged descendants', async () => {
+		const db = makeDB()
+		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
+		const reblogger = await createTestUser(domain, db, userKEK, 'reblogger@cloudflare.com')
+
+		const note = await createPublicStatus(domain, db, actor, 'a post', [], { sensitive: false })
+		await sleep(10)
+		const reply = await createReply(domain, db, actor, note, '@sven@cloudflare.com a reply')
+		await createReblog(db, reblogger, reply, {
+			to: [PUBLIC_GROUP],
+			cc: [],
+			id: 'https://example.com/reblogged-reply',
+		})
+
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]!}/context`)
+		const res = await app.fetch(req, { DATABASE: db })
+		await assertStatus(res, 200)
+
+		const data = await res.json<{ descendants: Array<{ account: { username: string } }> }>()
+		assert.equal(data.descendants.length, 1)
+		assert.equal(data.descendants[0].account.username, 'sven')
 	})
 })

--- a/packages/backend/src/routes/api/v1/statuses/[id]/context.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/context.test.ts
@@ -8,7 +8,6 @@ import { createPublicStatus, createReply } from '@wildebeest/backend/test/shared
 import { makeDB, createTestUser, assertStatus } from '@wildebeest/backend/test/utils'
 
 const userKEK = 'test_kek4'
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 const domain = 'cloudflare.com'
 
 describe('/api/v1/statuses/[id]/context', () => {
@@ -16,12 +15,11 @@ describe('/api/v1/statuses/[id]/context', () => {
 		const db = makeDB()
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 
-		const note = await createPublicStatus(domain, db, actor, 'a post', [], { sensitive: false })
-		await sleep(10)
+		const note = await createPublicStatus(domain, db, actor, 'a post')
 
 		await createReply(domain, db, actor, note, '@sven@cloudflare.com a reply')
 
-		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]!}/context`)
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/context`)
 		const res = await app.fetch(req, { DATABASE: db })
 		await assertStatus(res, 200)
 
@@ -39,16 +37,16 @@ describe('/api/v1/statuses/[id]/context', () => {
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 		const reblogger = await createTestUser(domain, db, userKEK, 'reblogger@cloudflare.com')
 
-		const note = await createPublicStatus(domain, db, actor, 'a post', [], { sensitive: false })
-		await sleep(10)
+		const note = await createPublicStatus(domain, db, actor, 'a post')
 		const reply = await createReply(domain, db, actor, note, '@sven@cloudflare.com a reply')
-		await createReblog(db, reblogger, reply, {
+		const inserted = await createReblog(db, reblogger, reply, {
 			to: [PUBLIC_GROUP],
 			cc: [],
 			id: 'https://example.com/reblogged-reply',
 		})
+		assert.equal(inserted, true)
 
-		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]!}/context`)
+		const req = new Request(`https://${domain}/api/v1/statuses/${note[mastodonIdSymbol]}/context`)
 		const res = await app.fetch(req, { DATABASE: db })
 		await assertStatus(res, 200)
 


### PR DESCRIPTION
## Summary
- Enforce status visibility on status lookup, account status lists, and timelines.
- Hide blocked or muted accounts from timeline and account status read paths.
- Reject follow requests when either side has blocked the other.

## Compatibility notes
- Some statuses that were previously visible can now return `404` or be omitted from arrays when privacy, block, or mute rules apply.

## Verification
- `pnpm run test`
- pre-commit `pretty` and `lint`
- pre-push `test`
