### PR TITLE
Clean up types across tests and crypto utilities

### DIFF
--- a/packages/backend/src/accounts/alias.test.ts
+++ b/packages/backend/src/accounts/alias.test.ts
@@ -15,7 +15,7 @@ describe('Settings', () => {
 
 		let receivedActivity: any = null
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Atest%40example.com') {
 					return new Response(

--- a/packages/backend/src/activitypub/activities/accept.test.ts
+++ b/packages/backend/src/activitypub/activities/accept.test.ts
@@ -16,7 +16,7 @@ const vapidKeys = {} as JWK
 
 describe('Accept', () => {
 	beforeEach(() => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof Request) {
 				throw new Error('unexpected request to ' + input.url)
 			}

--- a/packages/backend/src/activitypub/activities/create.test.ts
+++ b/packages/backend/src/activitypub/activities/create.test.ts
@@ -14,7 +14,7 @@ const vapidKeys = {} as JWK
 
 describe('Create', () => {
 	test('Object must be an object', async () => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://example.com/actor') {
 					return new Response(
@@ -80,7 +80,7 @@ describe('Create', () => {
 	test("Note adds in remote actor's outbox", async () => {
 		const remoteActorId = 'https://example.com/actor'
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === remoteActorId) {
 					return new Response(

--- a/packages/backend/src/activitypub/activities/follow.test.ts
+++ b/packages/backend/src/activitypub/activities/follow.test.ts
@@ -31,7 +31,7 @@ describe('Follow', () => {
 	beforeEach(() => {
 		receivedActivities = []
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			if (request.url === `https://${domain}/ap/users/sven2/inbox`) {
 				assert.equal(request.method, 'POST')

--- a/packages/backend/src/activitypub/actors/inbox.test.ts
+++ b/packages/backend/src/activitypub/actors/inbox.test.ts
@@ -17,7 +17,7 @@ describe('Inbox', () => {
 		const db = makeDB()
 		const connectedActor = await createTestUser(domain, db, userKEK, 'someone@example.com')
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === connectedActor.id.toString()) {
 					return new Response(JSON.stringify({ publicKey: connectedActor.publicKey }))
@@ -54,7 +54,7 @@ describe('Inbox', () => {
 		const db = makeDB()
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === actor.id.toString()) {
 					return new Response(JSON.stringify({ publicKey: actor.publicKey }))

--- a/packages/backend/src/activitypub/actors/index.test.ts
+++ b/packages/backend/src/activitypub/actors/index.test.ts
@@ -70,7 +70,7 @@ describe('Actors', () => {
 	})
 
 	test('sanitize Actor properties', async () => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://example.com/actor') {
 					return new Response(
@@ -96,7 +96,7 @@ describe('Actors', () => {
 	})
 
 	test('Actor properties limits', async () => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://example.com/actor') {
 					return new Response(
@@ -124,7 +124,7 @@ describe('Actors', () => {
 	test('getAndCache adds peer', async () => {
 		const actorId = new URL('https://example.com/user/foo')
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === actorId.toString()) {
 					return new Response(
@@ -162,7 +162,7 @@ describe('Actors', () => {
 
 		const actorId = new URL('https://example.com/user/foo')
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === actorId.toString()) {
 					return new Response(

--- a/packages/backend/src/activitypub/objects/collection.test.ts
+++ b/packages/backend/src/activitypub/objects/collection.test.ts
@@ -9,7 +9,7 @@ describe('Collection', () => {
 			first: 'https://example.com/1',
 		} as any
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://example.com/1') {
 					return new Response(

--- a/packages/backend/src/mastodon/follow.test.ts
+++ b/packages/backend/src/mastodon/follow.test.ts
@@ -11,7 +11,7 @@ describe('Follow', () => {
 		const db = makeDB()
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://example.com/user/a') {
 					return new Response(

--- a/packages/backend/src/mastodon/notification.test.ts
+++ b/packages/backend/src/mastodon/notification.test.ts
@@ -66,7 +66,7 @@ describe('mastodon/notification', () => {
 			'verify',
 		])) as CryptoKeyPair
 
-		globalThis.fetch = async (input: RequestInfo, data: any) => {
+		globalThis.fetch = async (input, data: any) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://push.com') {
 					assert((data.headers['Authorization'] as string).includes('WebPush'))

--- a/packages/backend/src/mastodon/status.test.ts
+++ b/packages/backend/src/mastodon/status.test.ts
@@ -11,7 +11,7 @@ describe('mastodon/status', () => {
 		const db = makeDB()
 		await createTestUser(domain, db, userKEK, 'sven@example.com')
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://instance.horse/.well-known/webfinger?resource=acct%3Asven%40instance.horse') {
 					return new Response(

--- a/packages/backend/src/mastodon/status_visibility.test.ts
+++ b/packages/backend/src/mastodon/status_visibility.test.ts
@@ -17,15 +17,15 @@ describe('mastodon/status_visibility', () => {
 		)
 		assert.equal(
 			detectVisibility({
-				to: [{ id: followers }],
-				cc: [{ id: new URL(PUBLIC_GROUP) }],
+				to: [{ id: followers, type: 'Collection' }],
+				cc: [{ id: new URL(PUBLIC_GROUP), type: 'Collection' }],
 				followers,
 			}),
 			'unlisted'
 		)
 		assert.equal(
 			detectVisibility({
-				to: [{ id: followers }],
+				to: [{ id: followers, type: 'Collection' }],
 				cc: [],
 				followers,
 			}),

--- a/packages/backend/src/routes/api/v1/accounts/[id].test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id].test.ts
@@ -12,7 +12,7 @@ const domain = 'cloudflare.com'
 
 describe('/api/v1/accounts/[id]', () => {
 	test('get remote actor by id', async () => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asven%40social.com') {
 					return new Response(

--- a/packages/backend/src/routes/api/v1/accounts/[id]/follow.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/follow.test.ts
@@ -59,7 +59,7 @@ describe('/api/v1/accounts/[id]/follow', () => {
 	test('follow account', async () => {
 		let receivedActivity: any = null
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			if (request.url === 'https://example.com/.well-known/webfinger?resource=acct%3Aactor%40example.com') {
 				return new Response(
@@ -132,7 +132,7 @@ describe('/api/v1/accounts/[id]/follow', () => {
 	test('follow keeps local state when remote delivery fails', async () => {
 		let inboxRequests = 0
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			if (request.url === 'https://example.com/.well-known/webfinger?resource=acct%3Afailing%40example.com') {
 				return new Response(
@@ -188,7 +188,7 @@ describe('/api/v1/accounts/[id]/follow', () => {
 	})
 
 	test('follow updates settings for an existing relationship', async () => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			throw new Error('unexpected request to ' + request.url)
 		}

--- a/packages/backend/src/routes/api/v1/accounts/[id]/followers.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/followers.test.ts
@@ -15,7 +15,7 @@ describe('/api/v1/accounts/[id]/followers', () => {
 		const actorA = await createTestUser(domain, db, userKEK, 'a@cloudflare.com')
 		const connectedActor = await createTestUser(domain, db, userKEK, 'someone@example.com')
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
 					return new Response(
@@ -100,7 +100,7 @@ describe('/api/v1/accounts/[id]/followers', () => {
 	})
 
 	test('get local actor followers', async () => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://' + domain + '/ap/users/sven2') {
 					return new Response(

--- a/packages/backend/src/routes/api/v1/accounts/[id]/following.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/following.test.ts
@@ -11,7 +11,7 @@ const domain = 'cloudflare.com'
 
 describe('/api/v1/accounts/[id]/following', () => {
 	test('get local actor following', async () => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://' + domain + '/ap/users/sven2') {
 					return new Response(
@@ -46,7 +46,7 @@ describe('/api/v1/accounts/[id]/following', () => {
 		const connectedActor = await createTestUser(domain, db, userKEK, 'someone@example.com')
 		const actorA = await createTestUser(domain, db, userKEK, 'a@cloudflare.com')
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://example.com/.well-known/webfinger?resource=acct%3Asven%40example.com') {
 					return new Response(

--- a/packages/backend/src/routes/api/v1/accounts/[id]/statuses.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/statuses.test.ts
@@ -286,7 +286,7 @@ describe('/api/v1/accounts/[id]/statuses', () => {
 
 		const note = await createPublicStatus(domain, db, actorA, 'my localnote status')
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
 					return new Response(

--- a/packages/backend/src/routes/api/v1/accounts/[id]/unfollow.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/[id]/unfollow.test.ts
@@ -13,7 +13,7 @@ describe('/api/v1/accounts/[id]/unfollow', () => {
 	test('unfollow account', async () => {
 		let receivedActivity: any = null
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			if (request.url === 'https://example.com/.well-known/webfinger?resource=acct%3Aactor%40example.com') {
 				return new Response(

--- a/packages/backend/src/routes/api/v1/accounts/lookup.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/lookup.test.ts
@@ -25,7 +25,7 @@ describe('/api/v1/accounts/lookup', () => {
 	})
 
 	test('lookup remote actor', async () => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://social.com/.well-known/webfinger?resource=acct%3Asomeone%40social.com') {
 					return new Response(

--- a/packages/backend/src/routes/api/v1/accounts/update_credentials.test.ts
+++ b/packages/backend/src/routes/api/v1/accounts/update_credentials.test.ts
@@ -78,7 +78,7 @@ describe('/api/v1/accounts/update_credentials', () => {
 	})
 
 	test('update credentials avatar and header', async () => {
-		globalThis.fetch = async (input: RequestInfo, data: any) => {
+		globalThis.fetch = async (input, data: any) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input === 'https://api.cloudflare.com/client/v4/accounts/CF_ACCOUNT_ID/images/v1') {
 					assert.equal(data.method, 'POST')

--- a/packages/backend/src/routes/api/v1/lists/[id]/accounts.ts
+++ b/packages/backend/src/routes/api/v1/lists/[id]/accounts.ts
@@ -36,7 +36,7 @@ app.get<'/accounts'>(async ({ req, env }) => {
 			db: getDatabase(env),
 			connectedActorId: env.data.connectedActor.id.toString(),
 		},
-		req.param('id')
+		req.param('id') as string
 	)
 })
 
@@ -50,7 +50,7 @@ app.post<'/accounts'>(async ({ req, env }) => {
 			db: getDatabase(env),
 			connectedActorId: env.data.connectedActor.id.toString(),
 		},
-		req.param('id'),
+		req.param('id') as string,
 		req.raw
 	)
 })
@@ -65,7 +65,7 @@ app.delete<'/accounts'>(async ({ req, env }) => {
 			db: getDatabase(env),
 			connectedActorId: env.data.connectedActor.id.toString(),
 		},
-		req.param('id'),
+		req.param('id') as string,
 		req.raw
 	)
 })

--- a/packages/backend/src/routes/api/v1/statuses.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses.test.ts
@@ -215,7 +215,7 @@ describe('/api/v1/statuses', () => {
 		let deliveredNote: Note | null = null
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		globalThis.fetch = async (input: RequestInfo, data: any) => {
+		globalThis.fetch = async (input, data: any) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://remote.com/.well-known/webfinger?resource=acct%3Asven%40remote.com') {
 					return new Response(
@@ -309,7 +309,7 @@ describe('/api/v1/statuses', () => {
 		const actor = await createTestUser(domain, db, userKEK, 'sven@cloudflare.com')
 		const connectedActor = actor
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://cloudflare.com/.well-known/webfinger?resource=acct%3Asven%40cloudflare.com') {
 					return new Response(
@@ -672,7 +672,7 @@ describe('/api/v1/statuses', () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		let deliveredActivity2: any = null
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof Request) {
 				if (input.url === actor1.inbox.toString()) {
 					deliveredActivity1 = await input.json()

--- a/packages/backend/src/routes/api/v1/statuses/[id]/favourite.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/favourite.test.ts
@@ -46,7 +46,7 @@ describe('/api/v1/statuses/[id]/favourite', () => {
 			)
 			.run()
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			if (request.url === actor.id.toString() + '/inbox') {
 				assert.equal(request.method, 'POST')
@@ -103,7 +103,7 @@ describe('/api/v1/statuses/[id]/favourite', () => {
 			)
 			.run()
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			if (request.url === actor.id.toString() + '/inbox') {
 				return new Response('temporary failure', { status: 503 })

--- a/packages/backend/src/routes/api/v1/statuses/[id]/reblog.test.ts
+++ b/packages/backend/src/routes/api/v1/statuses/[id]/reblog.test.ts
@@ -164,7 +164,7 @@ describe('/api/v1/statuses/[id]/reblog', () => {
 			)
 			.run()
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			if (request.url === 'https://cloudflare.com/ap/users/sven/inbox') {
 				assert.equal(request.method, 'POST')
@@ -222,7 +222,7 @@ describe('/api/v1/statuses/[id]/reblog', () => {
 			)
 			.run()
 
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			if (request.url === actor.id.toString() + '/inbox') {
 				return new Response('temporary failure', { status: 503 })

--- a/packages/backend/src/routes/api/v2/media.test.ts
+++ b/packages/backend/src/routes/api/v2/media.test.ts
@@ -11,7 +11,7 @@ const domain = 'cloudflare.com'
 
 describe('/api/v2/media', () => {
 	test('upload image creates object', async () => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			const request = new Request(input)
 			if (request.url.toString() === 'https://api.cloudflare.com/client/v4/accounts/testaccountid/images/v1') {
 				return new Response(

--- a/packages/backend/src/routes/api/v2/search.test.ts
+++ b/packages/backend/src/routes/api/v2/search.test.ts
@@ -9,7 +9,7 @@ const domain = 'cloudflare.com'
 
 describe('/api/v2/search', () => {
 	beforeEach(() => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://remote.com/.well-known/webfinger?resource=acct%3Asven%40remote.com') {
 					return new Response(

--- a/packages/backend/src/routes/first-login.test.ts
+++ b/packages/backend/src/routes/first-login.test.ts
@@ -12,7 +12,7 @@ const accessAud = 'abcd'
 
 describe('/first-login', () => {
 	beforeEach(() => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://' + accessDomain + '/cdn-cgi/access/certs') {
 					return new Response(JSON.stringify(ACCESS_CERTS))

--- a/packages/backend/src/routes/first-login.ts
+++ b/packages/backend/src/routes/first-login.ts
@@ -32,9 +32,9 @@ async function handlePostRequest(
 	const url = new URL(request.url)
 	const cookie = parse(request.headers.get('Cookie') || '')
 	let email = ''
-	const jwt = cookie['CF_Authorization']
+	const jwt = cookie['CF_Authorization'] ?? ''
 	try {
-		email = getJwtEmail(jwt ?? '')
+		email = getJwtEmail(jwt)
 	} catch (e) {
 		return errors.notAuthorized((e as Error)?.message)
 	}

--- a/packages/backend/src/routes/oauth/authorize.test.ts
+++ b/packages/backend/src/routes/oauth/authorize.test.ts
@@ -10,7 +10,7 @@ const accessAud = 'abcd'
 
 describe('/oauth/authorize', () => {
 	beforeEach(() => {
-		globalThis.fetch = async (input: RequestInfo) => {
+		globalThis.fetch = async (input) => {
 			if (input instanceof URL || typeof input === 'string') {
 				if (input.toString() === 'https://' + accessDomain + '/cdn-cgi/access/certs') {
 					return new Response(JSON.stringify(ACCESS_CERTS))

--- a/packages/backend/src/utils/hono.ts
+++ b/packages/backend/src/utils/hono.ts
@@ -363,7 +363,7 @@ if (import.meta.vitest) {
 		const accessAud = 'abcd'
 
 		test('test no identity', async () => {
-			globalThis.fetch = async (input: RequestInfo) => {
+			globalThis.fetch = async (input) => {
 				if (input instanceof URL || typeof input === 'string') {
 					if (input.toString() === 'https://' + accessDomain + '/cdn-cgi/access/certs') {
 						return Promise.resolve(new Response(JSON.stringify(ACCESS_CERTS)))
@@ -395,7 +395,7 @@ if (import.meta.vitest) {
 		})
 
 		test('test user not found', async () => {
-			globalThis.fetch = (input: RequestInfo) => {
+			globalThis.fetch = (input) => {
 				if (input instanceof URL || typeof input === 'string') {
 					if (input.toString() === 'https://' + accessDomain + '/cdn-cgi/access/certs') {
 						return Promise.resolve(new Response(JSON.stringify(ACCESS_CERTS)))
@@ -432,7 +432,7 @@ if (import.meta.vitest) {
 		})
 
 		test('success passes data and calls next', async () => {
-			globalThis.fetch = (input: RequestInfo) => {
+			globalThis.fetch = (input) => {
 				if (input instanceof URL || typeof input === 'string') {
 					if (input.toString() === 'https://' + accessDomain + '/cdn-cgi/access/certs') {
 						return Promise.resolve(new Response(JSON.stringify(ACCESS_CERTS)))

--- a/packages/backend/src/utils/key-ops.ts
+++ b/packages/backend/src/utils/key-ops.ts
@@ -1,6 +1,9 @@
-export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+export function arrayBufferToBase64(buffer: BufferSource): string {
 	let binary = ''
-	const bytes = new Uint8Array(buffer)
+	const bytes =
+		buffer instanceof ArrayBuffer
+			? new Uint8Array(buffer)
+			: new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
 	const len = bytes.byteLength
 	for (let i = 0; i < len; i++) {
 		binary += String.fromCharCode(bytes[i])
@@ -29,9 +32,9 @@ function getKeyMaterial(password: string): Promise<CryptoKey> {
 
 /*
 Given some key material and some random salt
-derive an AES-KW key using PBKDF2.
+derive an AES-GCM key using PBKDF2.
 */
-function getKey(keyMaterial: CryptoKey, salt: ArrayBuffer): Promise<CryptoKey> {
+function getKey(keyMaterial: CryptoKey, salt: BufferSource): Promise<CryptoKey> {
 	return crypto.subtle.deriveKey(
 		{
 			name: 'PBKDF2',
@@ -56,7 +59,7 @@ async function wrapCryptoKey(
 	// get the key encryption key
 	const keyMaterial = await getKeyMaterial(userKEK)
 	const salt = crypto.getRandomValues(new Uint8Array(16))
-	const wrappingKey = await getKey(keyMaterial, salt.buffer)
+	const wrappingKey = await getKey(keyMaterial, salt)
 	const bytesToWrap = await crypto.subtle.exportKey('pkcs8', keyToWrap)
 	const wrappedPrivKey = await crypto.subtle.encrypt(
 		{
@@ -100,11 +103,11 @@ Unwrap and import private key
 */
 export async function unwrapPrivateKey(
 	userKEK: string,
-	wrappedPrivKey: ArrayBuffer,
+	wrappedPrivKey: BufferSource,
 	salt: Uint8Array<ArrayBuffer>
 ): Promise<CryptoKey> {
 	const keyMaterial = await getKeyMaterial(userKEK)
-	const wrappingKey = await getKey(keyMaterial, salt.buffer)
+	const wrappingKey = await getKey(keyMaterial, salt)
 	const keyBytes = await crypto.subtle.decrypt(
 		{
 			name: 'AES-GCM',

--- a/packages/backend/src/webpush/hkdf.ts
+++ b/packages/backend/src/webpush/hkdf.ts
@@ -1,10 +1,10 @@
-export async function hmacSign(ikm: Uint8Array | ArrayBuffer, input: ArrayBuffer): Promise<ArrayBuffer> {
+export async function hmacSign(ikm: BufferSource, input: BufferSource): Promise<ArrayBuffer> {
 	const key = await crypto.subtle.importKey('raw', ikm, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
 	return await crypto.subtle.sign('HMAC', key, input)
 }
 
 export async function hkdfGenerate(
-	ikm: ArrayBuffer,
+	ikm: BufferSource,
 	salt: Uint8Array,
 	info: Uint8Array,
 	byteLength: number


### PR DESCRIPTION
## Summary

- Remove redundant `RequestInfo` type annotations from `globalThis.fetch` mocks across ~25 test files
- Widen crypto parameter types from `ArrayBuffer` to `BufferSource` in `key-ops.ts` and `hkdf.ts`
- Add `as string` type assertion to `req.param('id')` in list route handlers
- Simplify JWT cookie coalescing in `first-login.ts`
- Add `type: 'Collection'` property to ActivityPub objects in `status_visibility.test.ts`

## Why

These changes clean up type-related issues that were flagged by stricter TypeScript checks. Most are mechanical: removing redundant annotations, widening parameter types to accept both `ArrayBuffer` and `ArrayBufferView`, and adding explicit type assertions where Hono's param types are generic.

## Testing

- `pnpm run test` — all 326 tests pass across 79 test files
