### PR TITLE
feat(tf): add preview deployment config

### DIFF
--- a/tf/main.tf
+++ b/tf/main.tf
@@ -104,6 +104,8 @@ resource "cloudflare_pages_project" "wildebeest_pages_project" {
   production_branch = "main"
 
   deployment_configs {
+    preview {}
+
     production {
       environment_variables = {
         CF_ACCOUNT_ID = sensitive(var.cloudflare_account_id)


### PR DESCRIPTION
## Summary

Enable preview (branch) deployments for the Cloudflare Pages project by adding an empty `preview {}` block under `deployment_configs`.

Previously only a `production` block was defined, so non-production branches would not deploy to Cloudflare Pages.

## Testing

- Verified Terraform config is syntactically valid
- Tests pass: `pnpm run test` (355 passed)