### PR TITLE
chore: add lint scripts to consumer & do packages

### DIFF
--- a/packages/consumer/package.json
+++ b/packages/consumer/package.json
@@ -2,7 +2,8 @@
 	"name": "@wildebeest/consumer",
 	"version": "0.0.0",
 	"scripts": {
-		"preinstall": "npx only-allow pnpm"
+		"preinstall": "npx only-allow pnpm",
+		"lint": "eslint src --quiet"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "4.20260627.1",

--- a/packages/do/package.json
+++ b/packages/do/package.json
@@ -9,6 +9,7 @@
 	"private": true,
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
+		"lint": "eslint src --quiet",
 		"start": "wrangler dev",
 		"deploy": "wrangler deploy"
 	}


### PR DESCRIPTION
## Summary

Add `lint` scripts to `packages/consumer` and `packages/do` so they can be linted independently, consistent with other packages in the monorepo.

## Why

Both packages already have ESLint configuration and dev dependencies, but were missing the `lint` npm script. This makes it possible to run linting for these packages directly (e.g., via `pnpm --filter`) and ensures they are included in any workspace-level lint orchestration.

## Testing

- `pnpm --filter @wildebeest/consumer run lint` (no errors)
- `pnpm --filter @wildebeest/do run lint` (no errors)
- All existing tests continue to pass (355 passed)